### PR TITLE
[GN-31] feat: support .NET 6, 7, and 8 package targets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
     id: version
     attributes:
       label: Package version
-      placeholder: 0.1.0-preview.12.1
+      placeholder: 1.0.1-preview.12.1
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore GigaChat.Net.slnx

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -15,7 +15,7 @@ env:
   GIGACHAT_AUTH_URL: https://auth.example.test/oauth
   NUGET_SOURCE: https://api.nuget.org/v3/index.json
   GITHUB_PACKAGES_SOURCE: https://nuget.pkg.github.com/h0tnanny/index.json
-  PACKAGE_VERSION: 0.1.0-preview.${{ github.run_number }}.${{ github.run_attempt }}
+  PACKAGE_VERSION: 1.0.1-preview.${{ github.run_number }}.${{ github.run_attempt }}
 
 jobs:
   publish-preview:
@@ -31,7 +31,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+            10.0.x
 
       - name: Validate preview source
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,7 +33,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+            10.0.x
 
       - name: Resolve package version
         id: version

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 .NET SDK для [GigaChat REST API](https://developers.sber.ru/docs/ru/gigachat/api/reference/rest/gigachat-api) — большой языковой модели от Сбера.
 
-Полный порт Python библиотеки [gigachat](https://github.com/ai-forever/gigachat) на C# / .NET 10.
+Полный порт Python библиотеки [gigachat](https://github.com/ai-forever/gigachat) на C# / .NET.
 
 ## Статус проекта
 
@@ -39,7 +39,7 @@ dotnet add package GigaChat.Net
 dotnet add package GigaChat.Net.AspNetCore
 ```
 
-**Требования:** .NET 10.0+
+**Требования:** .NET 6.0, .NET 7.0 или .NET 8.0
 
 ## Пакеты и репозиторий
 
@@ -688,7 +688,7 @@ foreach (var entry in balance.BalanceEntries)
 - Pull requests проверяются workflow `CI`: restore, build, test и pack обоих NuGet-пакетов.
 - Разработка ведется через `develop`; feature и bugfix ветки создаются от `develop` в формате `feature/GN-123-short-description`.
 - Коммиты и PR title ведутся в формате `[GN-123] feat: short description`.
-- Push в `develop` публикует preview версии вида `0.1.0-preview.<run>.<attempt>` в NuGet.org и GitHub Packages и создает tag `preview/v...`.
+- Push в `develop` публикует preview версии вида `1.0.1-preview.<run>.<attempt>` в NuGet.org и GitHub Packages и создает tag `preview/v...`.
 - Stable tag `vX.Y.Z` из `master` публикует release версию в NuGet.org и GitHub Packages.
 - Для публикации нужен GitHub Actions secret `NUGET_API_KEY`.
 - GitHub Packages не зеркалирует NuGet.org автоматически; CI отдельно публикует тот же `.nupkg`, чтобы пакет появился во вкладке `Packages`.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -53,7 +53,7 @@ GitHub Project создается отдельно через GitHub UI или G
 | Type | Single select | `Bug`, `Task`, `Feature`, `Docs`, `CI` |
 | Area | Single select | `SDK`, `ASP.NET Core`, `CI/CD`, `Docs`, `Examples` |
 | Priority | Single select | `P0`, `P1`, `P2`, `P3` |
-| Version | Text | Например `0.1.0-preview`, `0.1.0`, `1.0.0` |
+| Version | Text | Например `1.0.1-preview`, `1.0.1`, `1.1.0` |
 
 ## Secrets
 
@@ -122,7 +122,7 @@ Workflow `Publish Preview NuGet Packages` запускается на кажды
 Версия preview формируется автоматически:
 
 ```text
-0.1.0-preview.<github.run_number>.<github.run_attempt>
+1.0.1-preview.<github.run_number>.<github.run_attempt>
 ```
 
 Preview workflow:
@@ -134,15 +134,15 @@ Preview workflow:
 5. Упаковывает оба проекта.
 6. Публикует `.nupkg` и `.snupkg` в nuget.org.
 7. Публикует `.nupkg` в GitHub Packages.
-8. Создает annotated tag вида `preview/v0.1.0-preview.<run>.<attempt>`.
+8. Создает annotated tag вида `preview/v1.0.1-preview.<run>.<attempt>`.
 
 GitHub Packages не является зеркалом NuGet.org. Даже если NuGet пакет содержит `RepositoryUrl` и связан с GitHub репозиторием, вкладка GitHub `Packages` покажет пакет только после отдельной публикации в GitHub Packages. Поэтому workflow публикует один и тот же `.nupkg` в оба registry.
 
 Установка preview версии:
 
 ```bash
-dotnet add package GigaChat.Net --version 0.1.0-preview.<run>.<attempt>
-dotnet add package GigaChat.Net.AspNetCore --version 0.1.0-preview.<run>.<attempt>
+dotnet add package GigaChat.Net --version 1.0.1-preview.<run>.<attempt>
+dotnet add package GigaChat.Net.AspNetCore --version 1.0.1-preview.<run>.<attempt>
 ```
 
 Preview пакеты подходят для проверки интеграции до стабильного релиза. Их не стоит считать контрактом совместимости.
@@ -156,8 +156,8 @@ dotnet nuget add source "https://nuget.pkg.github.com/h0tnanny/index.json" \
   --password "<github-token>" \
   --store-password-in-clear-text
 
-dotnet add package GigaChat.Net --version 0.1.0-preview.<run>.<attempt> --source github
-dotnet add package GigaChat.Net.AspNetCore --version 0.1.0-preview.<run>.<attempt> --source github
+dotnet add package GigaChat.Net --version 1.0.1-preview.<run>.<attempt> --source github
+dotnet add package GigaChat.Net.AspNetCore --version 1.0.1-preview.<run>.<attempt> --source github
 ```
 
 Для обычных пользователей предпочтительнее установка из NuGet.org без дополнительного source.
@@ -169,11 +169,11 @@ Workflow `Publish Release NuGet Packages` запускается двумя сп
 Первый способ - stable tag из `master`:
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag v1.0.1
+git push origin v1.0.1
 ```
 
-Workflow возьмет tag, удалит начальную `v` и опубликует NuGet версию `0.1.0`.
+Workflow возьмет tag, удалит начальную `v` и опубликует NuGet версию `1.0.1`.
 Release tag должен указывать на commit, который содержится в `master`.
 
 Второй способ - GitHub Release:
@@ -218,28 +218,21 @@ Release workflow принимает только stable SemVer:
 dotnet restore GigaChat.Net.slnx
 dotnet build GigaChat.Net.slnx --configuration Release --no-restore
 dotnet test GigaChat.Net.slnx --configuration Release --no-build
-dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=0.1.0-local
-dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=0.1.0-local
+dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=1.0.1-local
+dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=1.0.1-local
 ```
 
 Локальная установка из папки:
 
 ```bash
 dotnet nuget add source ./artifacts/packages --name GigaChatLocal
-dotnet add package GigaChat.Net --version 0.1.0-local --source ./artifacts/packages
-dotnet add package GigaChat.Net.AspNetCore --version 0.1.0-local --source ./artifacts/packages
+dotnet add package GigaChat.Net --version 1.0.1-local --source ./artifacts/packages
+dotnet add package GigaChat.Net.AspNetCore --version 1.0.1-local --source ./artifacts/packages
 ```
 
 ## Версионирование
 
-До первого стабильного релиза используйте ветку версий `0.x`:
-
-- `0.1.0-preview.<run>.<attempt>` - автоматические preview сборки из `develop`, помеченные tag `preview/v0.1.0-preview.<run>.<attempt>`.
-- `0.1.0` - первый стабильный публичный release.
-- `0.2.0` - новые совместимые возможности.
-- `0.1.1` - исправления без изменения публичного API.
-
-После `1.0.0` желательно следовать SemVer:
+После `1.0.0` следуйте SemVer:
 
 - `MAJOR` - breaking changes.
 - `MINOR` - новые возможности без breaking changes.

--- a/docs/nuget/GigaChat.Net.AspNetCore.md
+++ b/docs/nuget/GigaChat.Net.AspNetCore.md
@@ -20,7 +20,7 @@ https://github.com/h0tnanny/GigaChat-Net/issues
 dotnet add package GigaChat.Net.AspNetCore
 ```
 
-Пакет зависит от `GigaChat.Net` и рассчитан на .NET 10.0 или новее.
+Пакет зависит от `GigaChat.Net` и поддерживает .NET 6.0, .NET 7.0 и .NET 8.0.
 
 ## Быстрый старт
 

--- a/docs/nuget/GigaChat.Net.md
+++ b/docs/nuget/GigaChat.Net.md
@@ -20,7 +20,7 @@ https://github.com/h0tnanny/GigaChat-Net/issues
 dotnet add package GigaChat.Net
 ```
 
-Требуется .NET 10.0 или новее.
+Поддерживаются .NET 6.0, .NET 7.0 и .NET 8.0.
 
 ## Быстрый старт
 

--- a/examples/GigaChat.AspNetCore.Example/GigaChat.AspNetCore.Example.csproj
+++ b/examples/GigaChat.AspNetCore.Example/GigaChat.AspNetCore.Example.csproj
@@ -5,7 +5,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/GigaChat.Example/GigaChat.Example.csproj
+++ b/examples/GigaChat.Example/GigaChat.Example.csproj
@@ -6,7 +6,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj
+++ b/src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <!-- NuGet Package Metadata -->
     <PackageId>GigaChat.Net.AspNetCore</PackageId>
-    <Version>0.1.0-preview.1</Version>
+    <Version>1.0.1</Version>
     <Authors>GigaChat.Net Contributors</Authors>
     <Description>ASP.NET Core dependency injection and request context extensions for GigaChat.Net.</Description>
     <PackageTags>gigachat;aspnetcore;dependency-injection;ai;llm;sber;extensions</PackageTags>
@@ -17,7 +18,7 @@
     <RepositoryUrl>https://github.com/h0tnanny/GigaChat-Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/h0tnanny/GigaChat-Net</PackageProjectUrl>
-    <PackageReleaseNotes>Initial preview release of ASP.NET Core extensions for GigaChat.Net.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add package targets for .NET 6, .NET 7, and .NET 8 consumers.</PackageReleaseNotes>
 
     <!-- Symbol and Source Link -->
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/GigaChat.Net.AspNetCore/GigaChatServiceCollectionExtensions.cs
+++ b/src/GigaChat.Net.AspNetCore/GigaChatServiceCollectionExtensions.cs
@@ -107,7 +107,7 @@ public static class GigaChatServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentException.ThrowIfNullOrWhiteSpace(sectionName);
+        ThrowIfNullOrWhiteSpace(sectionName, nameof(sectionName));
 
         return services.AddGigaChat(
             options => ApplyConfiguration(configuration.GetSection(sectionName), options),
@@ -128,7 +128,7 @@ public static class GigaChatServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentException.ThrowIfNullOrWhiteSpace(sectionName);
+        ThrowIfNullOrWhiteSpace(sectionName, nameof(sectionName));
         ArgumentNullException.ThrowIfNull(httpClientFactory);
 
         return services.AddGigaChat(
@@ -347,5 +347,11 @@ public static class GigaChatServiceCollectionExtensions
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Select(value => value!)
             .ToList();
+    }
+
+    private static void ThrowIfNullOrWhiteSpace(string? value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be null or whitespace.", paramName);
     }
 }

--- a/src/GigaChat.Net/Compatibility/RequiredMemberAttributes.cs
+++ b/src/GigaChat.Net/Compatibility/RequiredMemberAttributes.cs
@@ -1,0 +1,35 @@
+#if NET6_0
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(
+        AttributeTargets.Class |
+        AttributeTargets.Struct |
+        AttributeTargets.Field |
+        AttributeTargets.Property,
+        AllowMultiple = false,
+        Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute;
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public const string RefStructs = nameof(RefStructs);
+        public const string RequiredMembers = nameof(RequiredMembers);
+
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+
+        public string FeatureName { get; }
+
+        public bool IsOptional { get; init; }
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : Attribute;
+}
+#endif

--- a/src/GigaChat.Net/FunctionTools.cs
+++ b/src/GigaChat.Net/FunctionTools.cs
@@ -96,7 +96,7 @@ public static class FunctionTool
         FunctionParameters? parameters = null,
         JsonSerializerOptions? jsonOptions = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        GigaChatGuard.ThrowIfNullOrWhiteSpace(name, nameof(name));
         ArgumentNullException.ThrowIfNull(handler);
 
         var function = new Function
@@ -127,7 +127,7 @@ public sealed class FunctionTool<TArguments> : IChatFunctionTool
         JsonSerializerOptions? jsonOptions = null)
     {
         ArgumentNullException.ThrowIfNull(function);
-        ArgumentException.ThrowIfNullOrWhiteSpace(function.Name);
+        GigaChatGuard.ThrowIfNullOrWhiteSpace(function.Name, nameof(function.Name));
         ArgumentNullException.ThrowIfNull(handler);
 
         Function = function;

--- a/src/GigaChat.Net/GigaChat.Net.csproj
+++ b/src/GigaChat.Net/GigaChat.Net.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     
     <!-- NuGet Package Metadata -->
     <PackageId>GigaChat.Net</PackageId>
-    <Version>0.1.0-preview.1</Version>
+    <Version>1.0.1</Version>
     <Authors>GigaChat.Net Contributors</Authors>
     <Description>.NET SDK for GigaChat REST API - a large language model by Sber. Full port of the Python gigachat library.</Description>
     <PackageTags>gigachat;ai;llm;sber;api;sdk;chat;completions;embeddings;streaming</PackageTags>
@@ -17,7 +18,7 @@
     <RepositoryUrl>https://github.com/h0tnanny/GigaChat-Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/h0tnanny/GigaChat-Net</PackageProjectUrl>
-    <PackageReleaseNotes>Initial preview release of the GigaChat.Net SDK.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add package targets for .NET 6, .NET 7, and .NET 8 consumers.</PackageReleaseNotes>
     
     <!-- Symbol and Source Link -->
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/GigaChat.Net/GigaChatClient.cs
+++ b/src/GigaChat.Net/GigaChatClient.cs
@@ -108,7 +108,7 @@ public sealed partial class GigaChatClient : IGigaChatClient, IDisposable
         _delay = delay ?? System.Threading.Thread.Sleep;
         _jsonOptions = new JsonSerializerOptions
         {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNamingPolicy = GigaChatJsonNamingPolicy.SnakeCaseLower,
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
         };
         _jsonOptions.Converters.Add(new SnakeCaseLowerEnumConverter<MessagesRole>());
@@ -226,9 +226,22 @@ public sealed partial class GigaChatClient : IGigaChatClient, IDisposable
                     settings.KeyFile);
         }
 
-        return string.IsNullOrEmpty(settings.KeyFilePassword)
-            ? X509CertificateLoader.LoadCertificateFromFile(settings.CertFile!)
-            : X509CertificateLoader.LoadPkcs12FromFile(settings.CertFile!, settings.KeyFilePassword);
+        return LoadPkcsCertificate(settings.CertFile!, settings.KeyFilePassword);
+    }
+
+    private static X509Certificate2 LoadPkcsCertificate(string certFile, string? password)
+    {
+#if NET9_0_OR_GREATER
+        return string.IsNullOrEmpty(password)
+            ? X509CertificateLoader.LoadCertificateFromFile(certFile)
+            : X509CertificateLoader.LoadPkcs12FromFile(certFile, password);
+#else
+#pragma warning disable SYSLIB0057
+        return string.IsNullOrEmpty(password)
+            ? new X509Certificate2(certFile)
+            : new X509Certificate2(certFile, password);
+#pragma warning restore SYSLIB0057
+#endif
     }
 
     private async Task<HttpRequestMessage> CreateRequestAsync(
@@ -617,7 +630,7 @@ public sealed partial class GigaChatClient : IGigaChatClient, IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var line = await reader.ReadLineAsync(cancellationToken);
+            var line = await ReadLineAsync(reader, cancellationToken);
             if (line is null)
                 break;
             if (TryDeserializeChunk(line, out T? chunk))
@@ -640,6 +653,16 @@ public sealed partial class GigaChatClient : IGigaChatClient, IDisposable
 
         chunk = JsonSerializer.Deserialize<T>(data, _jsonOptions);
         return chunk is not null;
+    }
+
+    private static ValueTask<string?> ReadLineAsync(StreamReader reader, CancellationToken cancellationToken)
+    {
+#if NET7_0_OR_GREATER
+        return reader.ReadLineAsync(cancellationToken);
+#else
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<string?>(reader.ReadLineAsync());
+#endif
     }
 
     private static string WithQuery(string path, IReadOnlyList<KeyValuePair<string, string?>> parameters)
@@ -866,7 +889,7 @@ public sealed partial class GigaChatClient : IGigaChatClient, IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
             
-            var line = await reader.ReadLineAsync(cancellationToken);
+            var line = await ReadLineAsync(reader, cancellationToken);
             if (line is null)
                 break;
             if (string.IsNullOrWhiteSpace(line))

--- a/src/GigaChat.Net/GigaChatGuard.cs
+++ b/src/GigaChat.Net/GigaChatGuard.cs
@@ -1,0 +1,10 @@
+namespace GigaChat.Net;
+
+internal static class GigaChatGuard
+{
+    public static void ThrowIfNullOrWhiteSpace(string? value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be null or whitespace.", paramName);
+    }
+}

--- a/src/GigaChat.Net/Models/FunctionHelpers.cs
+++ b/src/GigaChat.Net/Models/FunctionHelpers.cs
@@ -121,7 +121,7 @@ public static class FunctionSchema
 {
     internal static JsonSerializerOptions DefaultJsonOptions { get; } = new()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNamingPolicy = GigaChatJsonNamingPolicy.SnakeCaseLower,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 

--- a/src/GigaChat.Net/Models/JsonConverters.cs
+++ b/src/GigaChat.Net/Models/JsonConverters.cs
@@ -1,15 +1,103 @@
+using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace GigaChat.Net.Models;
 
-internal sealed class SnakeCaseLowerEnumConverter<TEnum> : JsonStringEnumConverter<TEnum>
+internal sealed class SnakeCaseLowerEnumConverter<TEnum> : JsonConverter<TEnum>
     where TEnum : struct, Enum
 {
-    /// <summary>
-    /// Executes the snake case lower enum converter operation.
-    /// </summary>
-    public SnakeCaseLowerEnumConverter() : base(JsonNamingPolicy.SnakeCaseLower)
+    private static readonly IReadOnlyDictionary<string, TEnum> ValuesByName = CreateValuesByName();
+
+    public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (value is not null && ValuesByName.TryGetValue(value, out var enumValue))
+                return enumValue;
+
+            throw new JsonException($"The JSON value '{value}' could not be converted to {typeof(TEnum)}.");
+        }
+
+        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt64(out var numericValue))
+            return (TEnum)Enum.ToObject(typeof(TEnum), numericValue);
+
+        throw new JsonException($"The JSON token {reader.TokenType} could not be converted to {typeof(TEnum)}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(GetJsonName(value));
+    }
+
+    private static IReadOnlyDictionary<string, TEnum> CreateValuesByName()
+    {
+        var values = new Dictionary<string, TEnum>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in Enum.GetValues<TEnum>())
+        {
+            var enumName = value.ToString();
+            values[enumName] = value;
+            values[GigaChatJsonNamingPolicy.SnakeCaseLower.ConvertName(enumName)] = value;
+            values[GetJsonName(value)] = value;
+        }
+
+        return values;
+    }
+
+    private static string GetJsonName(TEnum value)
+    {
+        var enumName = value.ToString();
+        var field = typeof(TEnum).GetField(enumName);
+        return field?.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
+            ?? GigaChatJsonNamingPolicy.SnakeCaseLower.ConvertName(enumName);
+    }
+}
+
+internal static class GigaChatJsonNamingPolicy
+{
+    public static JsonNamingPolicy SnakeCaseLower { get; } = new SnakeCaseLowerJsonNamingPolicy();
+}
+
+internal sealed class SnakeCaseLowerJsonNamingPolicy : JsonNamingPolicy
+{
+    public override string ConvertName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return name;
+
+        var builder = new StringBuilder(name.Length + 8);
+        for (var i = 0; i < name.Length; i++)
+        {
+            var current = name[i];
+            if (char.IsUpper(current))
+            {
+                if (ShouldInsertSeparator(name, i))
+                    builder.Append('_');
+
+                builder.Append(char.ToLowerInvariant(current));
+                continue;
+            }
+
+            builder.Append(current);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool ShouldInsertSeparator(string name, int index)
+    {
+        if (index == 0)
+            return false;
+
+        var previous = name[index - 1];
+        if (previous == '_')
+            return false;
+
+        if (!char.IsUpper(previous))
+            return true;
+
+        return index + 1 < name.Length && !char.IsUpper(name[index + 1]);
     }
 }

--- a/src/GigaChat.Net/Properties/AssemblyInfo.cs
+++ b/src/GigaChat.Net/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GigaChat.Net.Tests")]

--- a/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
+++ b/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\src\GigaChat.Net\Compatibility\RequiredMemberAttributes.cs" Link="Compatibility\RequiredMemberAttributes.cs" />
     <ProjectReference Include="..\..\src\GigaChat.Net.AspNetCore\GigaChat.Net.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\GigaChat.Net\GigaChat.Net.csproj" />
   </ItemGroup>

--- a/tests/GigaChat.Net.Tests/JsonContractTests.cs
+++ b/tests/GigaChat.Net.Tests/JsonContractTests.cs
@@ -7,7 +7,7 @@ public class JsonContractTests
 {
     private static readonly JsonSerializerOptions Options = new()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+        PropertyNamingPolicy = GigaChatJsonNamingPolicy.SnakeCaseLower
     };
 
     [Fact]

--- a/tests/GigaChat.Net.Tests/StructuredOutputTests.cs
+++ b/tests/GigaChat.Net.Tests/StructuredOutputTests.cs
@@ -129,7 +129,7 @@ public class StructuredOutputTests
     {
         var options = new JsonSerializerOptions
         {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+            PropertyNamingPolicy = GigaChatJsonNamingPolicy.SnakeCaseLower
         };
 
         var functions = JsonSerializer.Deserialize<OpenApiFunctions>(

--- a/tests/GigaChat.Net.Tests/TargetFrameworkCompatibilityTests.cs
+++ b/tests/GigaChat.Net.Tests/TargetFrameworkCompatibilityTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using System.Runtime.Versioning;
+using GigaChat.Net.AspNetCore;
+
+namespace GigaChat.Net.Tests;
+
+public class TargetFrameworkCompatibilityTests
+{
+    [Fact]
+    public void TestRunUsesMatchingSupportedTargetFramework()
+    {
+        var expectedFramework = GetExpectedTargetFramework();
+
+        Assert.Equal(expectedFramework, GetTargetFramework(typeof(TargetFrameworkCompatibilityTests).Assembly));
+        Assert.Equal(expectedFramework, GetTargetFramework(typeof(Settings).Assembly));
+        Assert.Equal(expectedFramework, GetTargetFramework(typeof(GigaChatOptions).Assembly));
+    }
+
+    private static string GetExpectedTargetFramework()
+    {
+#if NET6_0
+        return ".NETCoreApp,Version=v6.0";
+#elif NET7_0
+        return ".NETCoreApp,Version=v7.0";
+#elif NET8_0
+        return ".NETCoreApp,Version=v8.0";
+#else
+        throw new InvalidOperationException("Tests must run on net6.0, net7.0, or net8.0.");
+#endif
+    }
+
+    private static string GetTargetFramework(Assembly assembly)
+    {
+        return assembly.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName
+            ?? throw new InvalidOperationException($"Assembly {assembly.GetName().Name} does not declare TargetFrameworkAttribute.");
+    }
+}


### PR DESCRIPTION
## Summary
- Multi-target GigaChat.Net and GigaChat.Net.AspNetCore for net6.0, net7.0, and net8.0.
- Add compatibility shims for net6/net7 runtime API differences and explicit target-framework tests.
- Update CI/release workflows to install .NET 6/7/8 runtimes plus SDK 10 for .slnx builds.
- Bump package baseline to 1.0.1 and refresh docs/NuGet metadata.

Closes #31.

## Verification
- C:\\tmp\\dotnet\\dotnet.exe restore GigaChat.Net.slnx
- C:\\tmp\\dotnet\\dotnet.exe build GigaChat.Net.slnx --configuration Release --no-restore
- C:\\tmp\\dotnet\\dotnet.exe test GigaChat.Net.slnx --configuration Release --no-build
  - net6.0: 71 passed
  - net7.0: 71 passed
  - net8.0: 71 passed
- dotnet pack both packages /p:PackageVersion=1.0.1
- inspected nupkg lib/net6.0, lib/net7.0, lib/net8.0 entries