### PR TITLE
[GN-31] test: stabilize multitarget CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet build GigaChat.Net.slnx --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test GigaChat.Net.slnx --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
+        run: dotnet test GigaChat.Net.slnx --configuration Release --no-build --logger "trx;LogFilePrefix=test-results"
 
       - name: Pack
         run: |

--- a/tests/GigaChat.Net.Tests/ContextTests.cs
+++ b/tests/GigaChat.Net.Tests/ContextTests.cs
@@ -232,7 +232,8 @@ public class ContextTests
             new Settings
             {
                 AccessToken = "settings-token",
-                Model = "settings-model"
+                Model = "settings-model",
+                AllowModelOverrideFromHeader = false
             },
             handler);
 

--- a/tests/GigaChat.Net.Tests/TestAssemblyInfo.cs
+++ b/tests/GigaChat.Net.Tests/TestAssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary
- Disable xUnit test parallelization for process-wide environment/context tests.
- Make the model-override-disabled context test explicit about the disabled setting.
- Use TRX LogFilePrefix so multi-target test runs produce one result file per TFM.

## Verification
- C:\\tmp\\dotnet\\dotnet.exe restore GigaChat.Net.slnx
- C:\\tmp\\dotnet\\dotnet.exe build GigaChat.Net.slnx --configuration Release --no-restore
- C:\\tmp\\dotnet\\dotnet.exe test GigaChat.Net.slnx --configuration Release --no-build with TRX LogFilePrefix=test-results
- net6.0: 71 passed
- net7.0: 71 passed
- net8.0: 71 passed