### PR TITLE
[GN-35] feat: support net6 through net10 package targets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
     id: version
     attributes:
       label: Package version
-      placeholder: 1.0.1-preview.12.1
+      placeholder: 1.0.2-preview.12.1
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
             10.0.x
 
       - name: Restore
@@ -48,6 +49,10 @@ jobs:
         run: |
           dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=0.0.0-ci.${{ github.run_number }}.${{ github.run_attempt }}
           dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=0.0.0-ci.${{ github.run_number }}.${{ github.run_attempt }}
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -15,7 +15,7 @@ env:
   GIGACHAT_AUTH_URL: https://auth.example.test/oauth
   NUGET_SOURCE: https://api.nuget.org/v3/index.json
   GITHUB_PACKAGES_SOURCE: https://nuget.pkg.github.com/h0tnanny/index.json
-  PACKAGE_VERSION: 1.0.1-preview.${{ github.run_number }}.${{ github.run_attempt }}
+  PACKAGE_VERSION: 1.0.2-preview.${{ github.run_number }}.${{ github.run_attempt }}
 
 jobs:
   publish-preview:
@@ -35,6 +35,7 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
             10.0.x
 
       - name: Validate preview source
@@ -66,6 +67,10 @@ jobs:
         run: |
           dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=$PACKAGE_VERSION
           dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=$PACKAGE_VERSION
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
 
       - name: Publish packages to NuGet
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,6 +37,7 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
             10.0.x
 
       - name: Resolve package version
@@ -90,6 +91,10 @@ jobs:
         run: |
           dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=${{ steps.version.outputs.package_version }}
           dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=${{ steps.version.outputs.package_version }}
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
 
       - name: Publish packages to NuGet
         env:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dotnet add package GigaChat.Net
 dotnet add package GigaChat.Net.AspNetCore
 ```
 
-**Требования:** .NET 6.0, .NET 7.0 или .NET 8.0
+**Требования:** .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0 или .NET 10.0
 
 ## Пакеты и репозиторий
 
@@ -688,7 +688,7 @@ foreach (var entry in balance.BalanceEntries)
 - Pull requests проверяются workflow `CI`: restore, build, test и pack обоих NuGet-пакетов.
 - Разработка ведется через `develop`; feature и bugfix ветки создаются от `develop` в формате `feature/GN-123-short-description`.
 - Коммиты и PR title ведутся в формате `[GN-123] feat: short description`.
-- Push в `develop` публикует preview версии вида `1.0.1-preview.<run>.<attempt>` в NuGet.org и GitHub Packages и создает tag `preview/v...`.
+- Push в `develop` публикует preview версии вида `1.0.2-preview.<run>.<attempt>` в NuGet.org и GitHub Packages и создает tag `preview/v...`.
 - Stable tag `vX.Y.Z` из `master` публикует release версию в NuGet.org и GitHub Packages.
 - Для публикации нужен GitHub Actions secret `NUGET_API_KEY`.
 - GitHub Packages не зеркалирует NuGet.org автоматически; CI отдельно публикует тот же `.nupkg`, чтобы пакет появился во вкладке `Packages`.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -53,7 +53,7 @@ GitHub Project создается отдельно через GitHub UI или G
 | Type | Single select | `Bug`, `Task`, `Feature`, `Docs`, `CI` |
 | Area | Single select | `SDK`, `ASP.NET Core`, `CI/CD`, `Docs`, `Examples` |
 | Priority | Single select | `P0`, `P1`, `P2`, `P3` |
-| Version | Text | Например `1.0.1-preview`, `1.0.1`, `1.1.0` |
+| Version | Text | Например `1.0.2-preview`, `1.0.2`, `1.1.0` |
 
 ## Secrets
 
@@ -122,7 +122,7 @@ Workflow `Publish Preview NuGet Packages` запускается на кажды
 Версия preview формируется автоматически:
 
 ```text
-1.0.1-preview.<github.run_number>.<github.run_attempt>
+1.0.2-preview.<github.run_number>.<github.run_attempt>
 ```
 
 Preview workflow:
@@ -134,15 +134,15 @@ Preview workflow:
 5. Упаковывает оба проекта.
 6. Публикует `.nupkg` и `.snupkg` в nuget.org.
 7. Публикует `.nupkg` в GitHub Packages.
-8. Создает annotated tag вида `preview/v1.0.1-preview.<run>.<attempt>`.
+8. Создает annotated tag вида `preview/v1.0.2-preview.<run>.<attempt>`.
 
 GitHub Packages не является зеркалом NuGet.org. Даже если NuGet пакет содержит `RepositoryUrl` и связан с GitHub репозиторием, вкладка GitHub `Packages` покажет пакет только после отдельной публикации в GitHub Packages. Поэтому workflow публикует один и тот же `.nupkg` в оба registry.
 
 Установка preview версии:
 
 ```bash
-dotnet add package GigaChat.Net --version 1.0.1-preview.<run>.<attempt>
-dotnet add package GigaChat.Net.AspNetCore --version 1.0.1-preview.<run>.<attempt>
+dotnet add package GigaChat.Net --version 1.0.2-preview.<run>.<attempt>
+dotnet add package GigaChat.Net.AspNetCore --version 1.0.2-preview.<run>.<attempt>
 ```
 
 Preview пакеты подходят для проверки интеграции до стабильного релиза. Их не стоит считать контрактом совместимости.
@@ -156,8 +156,8 @@ dotnet nuget add source "https://nuget.pkg.github.com/h0tnanny/index.json" \
   --password "<github-token>" \
   --store-password-in-clear-text
 
-dotnet add package GigaChat.Net --version 1.0.1-preview.<run>.<attempt> --source github
-dotnet add package GigaChat.Net.AspNetCore --version 1.0.1-preview.<run>.<attempt> --source github
+dotnet add package GigaChat.Net --version 1.0.2-preview.<run>.<attempt> --source github
+dotnet add package GigaChat.Net.AspNetCore --version 1.0.2-preview.<run>.<attempt> --source github
 ```
 
 Для обычных пользователей предпочтительнее установка из NuGet.org без дополнительного source.
@@ -169,11 +169,11 @@ Workflow `Publish Release NuGet Packages` запускается двумя сп
 Первый способ - stable tag из `master`:
 
 ```bash
-git tag v1.0.1
-git push origin v1.0.1
+git tag v1.0.2
+git push origin v1.0.2
 ```
 
-Workflow возьмет tag, удалит начальную `v` и опубликует NuGet версию `1.0.1`.
+Workflow возьмет tag, удалит начальную `v` и опубликует NuGet версию `1.0.2`.
 Release tag должен указывать на commit, который содержится в `master`.
 
 Второй способ - GitHub Release:
@@ -218,16 +218,16 @@ Release workflow принимает только stable SemVer:
 dotnet restore GigaChat.Net.slnx
 dotnet build GigaChat.Net.slnx --configuration Release --no-restore
 dotnet test GigaChat.Net.slnx --configuration Release --no-build
-dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=1.0.1-local
-dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=1.0.1-local
+dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=1.0.2-local
+dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=1.0.2-local
 ```
 
 Локальная установка из папки:
 
 ```bash
 dotnet nuget add source ./artifacts/packages --name GigaChatLocal
-dotnet add package GigaChat.Net --version 1.0.1-local --source ./artifacts/packages
-dotnet add package GigaChat.Net.AspNetCore --version 1.0.1-local --source ./artifacts/packages
+dotnet add package GigaChat.Net --version 1.0.2-local --source ./artifacts/packages
+dotnet add package GigaChat.Net.AspNetCore --version 1.0.2-local --source ./artifacts/packages
 ```
 
 ## Версионирование

--- a/docs/nuget/GigaChat.Net.AspNetCore.md
+++ b/docs/nuget/GigaChat.Net.AspNetCore.md
@@ -20,7 +20,7 @@ https://github.com/h0tnanny/GigaChat-Net/issues
 dotnet add package GigaChat.Net.AspNetCore
 ```
 
-Пакет зависит от `GigaChat.Net` и поддерживает .NET 6.0, .NET 7.0 и .NET 8.0.
+Пакет зависит от `GigaChat.Net` и поддерживает .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0 и .NET 10.0.
 
 ## Быстрый старт
 

--- a/docs/nuget/GigaChat.Net.md
+++ b/docs/nuget/GigaChat.Net.md
@@ -20,7 +20,7 @@ https://github.com/h0tnanny/GigaChat-Net/issues
 dotnet add package GigaChat.Net
 ```
 
-Поддерживаются .NET 6.0, .NET 7.0 и .NET 8.0.
+Поддерживаются .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0 и .NET 10.0.
 
 ## Быстрый старт
 

--- a/scripts/Validate-PackageFrameworks.ps1
+++ b/scripts/Validate-PackageFrameworks.ps1
@@ -1,0 +1,29 @@
+param(
+    [string] $PackageDirectory = "artifacts/packages",
+    [string[]] $Frameworks = @("net6.0", "net7.0", "net8.0", "net9.0", "net10.0")
+)
+
+$packages = Get-ChildItem -Path $PackageDirectory -Filter "*.nupkg" -File
+if ($packages.Count -eq 0) {
+    throw "No .nupkg files found in '$PackageDirectory'."
+}
+
+foreach ($package in $packages) {
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
+    try {
+        $entryNames = $archive.Entries | ForEach-Object { $_.FullName }
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    foreach ($framework in $Frameworks) {
+        $prefix = "lib/$framework/"
+        $hasFramework = $entryNames | Where-Object { $_.StartsWith($prefix, [StringComparison]::Ordinal) } | Select-Object -First 1
+        if (-not $hasFramework) {
+            throw "Package '$($package.Name)' does not contain '$prefix'. NuGet will not show $framework as an included target framework."
+        }
+    }
+
+    Write-Host "Package '$($package.Name)' contains: $($Frameworks -join ', ')"
+}

--- a/src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj
+++ b/src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <!-- NuGet Package Metadata -->
     <PackageId>GigaChat.Net.AspNetCore</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>GigaChat.Net Contributors</Authors>
     <Description>ASP.NET Core dependency injection and request context extensions for GigaChat.Net.</Description>
     <PackageTags>gigachat;aspnetcore;dependency-injection;ai;llm;sber;extensions</PackageTags>
@@ -18,7 +18,7 @@
     <RepositoryUrl>https://github.com/h0tnanny/GigaChat-Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/h0tnanny/GigaChat-Net</PackageProjectUrl>
-    <PackageReleaseNotes>Add package targets for .NET 6, .NET 7, and .NET 8 consumers.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add explicit package targets for every .NET version from .NET 6 through .NET 10.</PackageReleaseNotes>
 
     <!-- Symbol and Source Link -->
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/GigaChat.Net/GigaChat.Net.csproj
+++ b/src/GigaChat.Net/GigaChat.Net.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     
     <!-- NuGet Package Metadata -->
     <PackageId>GigaChat.Net</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>GigaChat.Net Contributors</Authors>
     <Description>.NET SDK for GigaChat REST API - a large language model by Sber. Full port of the Python gigachat library.</Description>
     <PackageTags>gigachat;ai;llm;sber;api;sdk;chat;completions;embeddings;streaming</PackageTags>
@@ -18,7 +18,7 @@
     <RepositoryUrl>https://github.com/h0tnanny/GigaChat-Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/h0tnanny/GigaChat-Net</PackageProjectUrl>
-    <PackageReleaseNotes>Add package targets for .NET 6, .NET 7, and .NET 8 consumers.</PackageReleaseNotes>
+    <PackageReleaseNotes>Add explicit package targets for every .NET version from .NET 6 through .NET 10.</PackageReleaseNotes>
     
     <!-- Symbol and Source Link -->
     <IncludeSymbols>true</IncludeSymbols>

--- a/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
+++ b/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/GigaChat.Net.Tests/TargetFrameworkCompatibilityTests.cs
+++ b/tests/GigaChat.Net.Tests/TargetFrameworkCompatibilityTests.cs
@@ -24,8 +24,12 @@ public class TargetFrameworkCompatibilityTests
         return ".NETCoreApp,Version=v7.0";
 #elif NET8_0
         return ".NETCoreApp,Version=v8.0";
+#elif NET9_0
+        return ".NETCoreApp,Version=v9.0";
+#elif NET10_0
+        return ".NETCoreApp,Version=v10.0";
 #else
-        throw new InvalidOperationException("Tests must run on net6.0, net7.0, or net8.0.");
+        throw new InvalidOperationException("Tests must run on net6.0, net7.0, net8.0, net9.0, or net10.0.");
 #endif
     }
 


### PR DESCRIPTION
## Summary
- Add explicit net6.0, net7.0, net8.0, net9.0, and net10.0 package targets for both NuGet packages.
- Run tests across the same target framework range.
- Add package validation so CI/release fails if any .nupkg is missing lib/net6.0 through lib/net10.0 entries, which controls NuGet included-framework display.
- Bump follow-up release metadata to 1.0.2 after 1.0.1.

## Verification
- restore passed
- Release build passed
- tests passed across net6.0, net7.0, net8.0, net9.0, and net10.0: 71 passed per target
- pack 1.0.2 passed for GigaChat.Net and GigaChat.Net.AspNetCore
- Validate-PackageFrameworks.ps1 confirmed both nupkg files include lib/net6.0 through lib/net10.0

Closes #35