### PR TITLE
[GN-39] chore: release GigaChat.Net 1.1.0 with ReAct agent

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Package
       description: Which package is affected?
-      placeholder: GigaChat.Net or GigaChat.Net.AspNetCore
+      placeholder: GigaChat.Net, GigaChat.Net.AspNetCore, or GigaChat.Net.SemanticKernel
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
     id: package
     attributes:
       label: Package
-      placeholder: GigaChat.Net or GigaChat.Net.AspNetCore
+      placeholder: GigaChat.Net, GigaChat.Net.AspNetCore, or GigaChat.Net.SemanticKernel
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - develop
+      - semantic-kernel
   workflow_dispatch:
 
 permissions:
@@ -49,6 +50,19 @@ jobs:
         run: |
           dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=0.0.0-ci.${{ github.run_number }}.${{ github.run_attempt }}
           dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=0.0.0-ci.${{ github.run_number }}.${{ github.run_attempt }}
+          dotnet pack src/GigaChat.Net.SemanticKernel/GigaChat.Net.SemanticKernel.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=0.0.0-ci.${{ github.run_number }}.${{ github.run_attempt }}
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
 
       - name: Validate package frameworks
         shell: pwsh

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
           if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Release tags must be stable SemVer, for example v1.0.0. Preview versions are published from develop." >&2
+            echo "Release tags must be stable SemVer, for example v1.0.0. Preview versions are published from develop or semantic-kernel." >&2
             exit 1
           fi
 
@@ -91,6 +91,19 @@ jobs:
         run: |
           dotnet pack src/GigaChat.Net/GigaChat.Net.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=${{ steps.version.outputs.package_version }}
           dotnet pack src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=${{ steps.version.outputs.package_version }}
+          dotnet pack src/GigaChat.Net.SemanticKernel/GigaChat.Net.SemanticKernel.csproj --configuration Release --no-build --output artifacts/packages /p:PackageVersion=${{ steps.version.outputs.package_version }}
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
+
+      - name: Validate package frameworks
+        shell: pwsh
+        run: ./scripts/Validate-PackageFrameworks.ps1
 
       - name: Validate package frameworks
         shell: pwsh

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -42,8 +42,12 @@ jobs:
             exit 1
           fi
 
+          if [[ "$BASE_BRANCH" == "develop" && "$HEAD_BRANCH" == "semantic-kernel" ]]; then
+            branch_pattern="^semantic-kernel$"
+          fi
+
           if [[ "$BASE_BRANCH" == "develop" && ! "$HEAD_BRANCH" =~ $branch_pattern ]]; then
-            echo "Branches targeting develop must match feature/GN-123-short-description, bugfix/GN-123-short-description, and similar prefixes." >&2
+            echo "Branches targeting develop must match semantic-kernel, feature/GN-123-short-description, bugfix/GN-123-short-description, and similar prefixes." >&2
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,13 @@ bld/
 .idea/
 *.sln.iml
 
+# Local secrets and machine-specific configuration
+.env
+.env.*
+!.env.example
+appsettings.Development.json
+appsettings.Local.json
+
 # NuGet Packages
 *.nupkg
 *.snupkg

--- a/GigaChat.Net.slnx
+++ b/GigaChat.Net.slnx
@@ -2,10 +2,12 @@
   <Folder Name="/examples/">
     <Project Path="examples/GigaChat.AspNetCore.Example/GigaChat.AspNetCore.Example.csproj" />
     <Project Path="examples/GigaChat.Example/GigaChat.Example.csproj" />
+    <Project Path="examples/GigaChat.SemanticKernel.Example/GigaChat.SemanticKernel.Example.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj" />
     <Project Path="src/GigaChat.Net/GigaChat.Net.csproj" />
+    <Project Path="src/GigaChat.Net.SemanticKernel/GigaChat.Net.SemanticKernel.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj" />

--- a/docs/agents/react-agent.md
+++ b/docs/agents/react-agent.md
@@ -1,0 +1,125 @@
+# GigaChat ReAct Agent
+
+`GigaChatReActAgent` — высокоуровневый агент для паттерна **ReAct** (Reason + Act) поверх Semantic Kernel. Реализует циклы вызова инструментов с трейсингом шагов и поддержкой многооборотных диалогов.
+
+## Быстрый старт
+
+```csharp
+using GigaChat.Net;
+using GigaChat.Net.SemanticKernel;
+
+using var client = new GigaChatClient(new Settings
+{
+    Credentials = "base64-encoded-client-id:secret"
+});
+
+var agent = GigaChatReActAgent.Create(builder =>
+{
+    builder.UseClient(client);
+    builder.WithInstructions(GigaChatReActInstructions.DefaultRussian);
+    builder.AddPlugin(new MyPlugin(), "my");
+});
+
+var result = await agent.InvokeAsync("Что делать дальше?");
+Console.WriteLine(result.Messages[^1].Content);
+```
+
+## Fluent Builder
+
+| Метод | Описание |
+|---|---|
+| `UseClient(client)` | Передаёт существующий `IGigaChatClient` |
+| `UseSettings(settings)` | Создаёт клиент из `Settings` |
+| `WithInstructions(text)` | System-промпт, вставляется перед каждым запросом |
+| `WithMaxToolCalls(n)` | Лимит вызовов инструментов за один запуск (по умолчанию 8) |
+| `WithTemperature(t)` | Температура сэмплирования (по умолчанию 0.1) |
+| `WithModelId(id)` | Переключение модели GigaChat |
+| `WithToolSafety(opts)` | Политика ошибок, усечение вывода, разрешённые плагины |
+| `UseThreadStore(store)` | Включает многооборотные диалоги |
+| `AddPlugin(obj, name)` | Регистрирует плагин Semantic Kernel |
+| `AddKernelPlugin(plugin)` | Регистрирует готовый `KernelPlugin` |
+
+## Шаблоны инструкций
+
+`GigaChatReActInstructions` содержит готовые шаблоны:
+
+| Константа | Назначение |
+|---|---|
+| `DefaultRussian` | Общий агент (русский язык) |
+| `DefaultEnglish` | Общий агент (английский язык) |
+| `ToolFirst` | Всегда вызывать инструмент перед ответом |
+| `ReadOnlyResearch` | Только чтение, никаких мутаций |
+| `SupportAgent` | Поддержка пользователей с эскалацией |
+
+## Трейсинг шагов
+
+Каждый запуск возвращает `GigaChatAgentRunResult`:
+
+```csharp
+var result = await agent.InvokeAsync("вопрос");
+
+foreach (var step in result.Steps)
+{
+    switch (step)
+    {
+        case GigaChatToolCallStep call:
+            Console.WriteLine($"[{call.LatencyMs}ms] Вызов: {call.ToolName}");
+            break;
+        case GigaChatToolResultStep res:
+            Console.WriteLine($"[{res.LatencyMs}ms] Результат: {res.Result[..Math.Min(80, res.Result.Length)]}");
+            break;
+        case GigaChatAssistantMessageStep msg:
+            Console.WriteLine($"[{msg.LatencyMs}ms] Ответ (запрос #{msg.RequestIndex})");
+            break;
+    }
+}
+```
+
+## Многооборотные диалоги
+
+```csharp
+var store = new InMemoryGigaChatAgentThreadStore();
+
+var agent = GigaChatReActAgent.Create(builder =>
+{
+    builder.UseClient(client);
+    builder.WithInstructions(GigaChatReActInstructions.DefaultRussian);
+    builder.UseThreadStore(store);
+});
+
+await agent.InvokeAsync("Привет!", "my-thread");
+await agent.InvokeAsync("Что ты помнишь?", "my-thread");
+```
+
+История накапливается в store. Для production-развёртывания реализуйте `IGigaChatAgentThreadStore` поверх Redis, БД и т.д.
+
+## Безопасность инструментов
+
+```csharp
+builder.WithToolSafety(new GigaChatToolSafetyOptions
+{
+    // Ошибка инструмента отправляется обратно в модель вместо исключения
+    ErrorBehavior = GigaChatToolErrorBehavior.ReturnObservation,
+    // Ограничение размера вывода инструмента
+    MaxOutputLength = 2000,
+    // Только перечисленные плагины могут вызываться автоматически
+    AllowedPlugins = new HashSet<string> { "safe_plugin" }
+});
+```
+
+## Прямой доступ к RunWithStepsAsync
+
+Для большего контроля можно использовать `GigaChatChatCompletionService` напрямую:
+
+```csharp
+var service = new GigaChatChatCompletionService(client);
+
+var result = await service.RunWithStepsAsync(
+    history,
+    new GigaChatPromptExecutionSettings
+    {
+        FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+        MaxToolCalls = 10
+    },
+    kernel);
+```

--- a/docs/nuget/GigaChat.Net.AspNetCore.md
+++ b/docs/nuget/GigaChat.Net.AspNetCore.md
@@ -105,6 +105,62 @@ builder.Services.AddGigaChat(
     provider => provider.GetRequiredService<IHttpClientFactory>().CreateClient("GigaChat"));
 ```
 
+## Semantic Kernel в ASP.NET Core
+
+Если ASP.NET Core приложение использует Semantic Kernel, зарегистрируйте `Kernel`
+поверх уже настроенного `IGigaChatClient`. Для этого добавьте пакет
+`GigaChat.Net.SemanticKernel`. Если приложение напрямую использует типы
+`Kernel`, `IChatCompletionService` или `ChatHistory`, добавьте явную ссылку на
+`Microsoft.SemanticKernel`, чтобы IDE и build tooling видели эти типы без
+опоры на транзитивные зависимости.
+
+```bash
+dotnet add package GigaChat.Net.SemanticKernel
+dotnet add package Microsoft.SemanticKernel
+```
+
+```csharp
+using GigaChat.Net;
+using GigaChat.Net.AspNetCore;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+builder.Services.AddGigaChat(builder.Configuration);
+builder.Services.AddGigaChatSemanticKernel(options =>
+{
+    options.ModelIdFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.Model;
+    options.EndpointFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.BaseUrl;
+});
+
+app.MapPost("/semantic-kernel/chat", async (
+    ChatRequest request,
+    IChatCompletionService chat,
+    CancellationToken cancellationToken) =>
+{
+    ChatHistory history =
+    [
+        new ChatMessageContent(AuthorRole.System, "Ты ASP.NET Core ассистент."),
+        new ChatMessageContent(AuthorRole.User, request.Message)
+    ];
+
+    var response = await chat.GetChatMessageContentsAsync(
+        history,
+        new GigaChatPromptExecutionSettings
+        {
+            Temperature = 0.2,
+            MaxTokens = 700
+        },
+        cancellationToken: cancellationToken);
+
+    return Results.Ok(response[0].Content);
+});
+```
+
+Расширенный пример с endpoints для chat, streaming, structured output,
+Semantic Kernel plugins/tools и `ChatCompletionAgent` находится в
+`examples/GigaChat.AspNetCore.Example`.
+
 ## Документация
 
 Полная документация и пример приложения находятся в репозитории:

--- a/docs/nuget/GigaChat.Net.SemanticKernel.md
+++ b/docs/nuget/GigaChat.Net.SemanticKernel.md
@@ -1,0 +1,431 @@
+# GigaChat.Net.SemanticKernel
+
+`GigaChat.Net.SemanticKernel` - адаптер Microsoft Semantic Kernel для `GigaChat.Net`.
+Он регистрирует GigaChat как `IChatCompletionService`, чтобы GigaChat можно было
+использовать в `ChatHistory`, streaming, structured output, Kernel plugins/tools и
+`ChatCompletionAgent`.
+
+## Статус проекта
+
+Этот репозиторий ведется ИИ под контролем владельца проекта. Если при использовании
+Semantic Kernel интеграции вы обнаружите баг, несовместимость или неточность
+документации, пожалуйста, создайте GitHub Issue:
+
+https://github.com/h0tnanny/GigaChat-Net/issues
+
+## Что это и зачем
+
+Semantic Kernel дает единый слой для chat completion, агентов, plugins/functions,
+prompt execution settings и истории диалога. Этот пакет подключает к этому слою
+GigaChat, не заставляя приложение работать напрямую с HTTP payload GigaChat.
+
+Используйте пакет, когда приложение уже строится вокруг Semantic Kernel или когда
+нужны:
+
+- `IChatCompletionService` для `ChatHistory`;
+- streaming через `GetStreamingChatMessageContentsAsync`;
+- Semantic Kernel plugins/tools через `FunctionChoiceBehavior.Auto()`;
+- агенты `ChatCompletionAgent`;
+- structured output через GigaChat `response_format`;
+- GigaChat-настройки через `GigaChatPromptExecutionSettings`;
+- per-call headers через `GigaChatRequestHeaders`.
+
+Если Semantic Kernel не используется, достаточно базового пакета `GigaChat.Net`.
+
+## Установка
+
+```bash
+dotnet add package GigaChat.Net.SemanticKernel
+dotnet add package Microsoft.SemanticKernel
+```
+
+Для `ChatCompletionAgent` добавьте пакет агентов Semantic Kernel:
+
+```bash
+dotnet add package Microsoft.SemanticKernel.Agents.Core
+```
+
+Пакет зависит от `GigaChat.Net` и поддерживает .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0 и .NET 10.0.
+
+## Быстрый старт с DI
+
+Если приложение уже зарегистрировало `IGigaChatClient`, например через
+`GigaChat.Net.AspNetCore` `AddGigaChat(...)`, добавьте Semantic Kernel поверх
+этого SDK-клиента:
+
+```csharp
+using GigaChat.Net.AspNetCore;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+builder.Services.AddGigaChat(builder.Configuration);
+builder.Services.AddGigaChatSemanticKernel(options =>
+{
+    options.ModelIdFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.Model;
+    options.EndpointFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.BaseUrl;
+});
+
+app.MapPost("/chat", async (
+    ChatRequest request,
+    IChatCompletionService chat,
+    CancellationToken cancellationToken) =>
+{
+    ChatHistory history =
+    [
+        new ChatMessageContent(AuthorRole.System, "Ты полезный ассистент."),
+        new ChatMessageContent(AuthorRole.User, request.Message)
+    ];
+
+    var response = await chat.GetChatMessageContentsAsync(
+        history,
+        new GigaChatPromptExecutionSettings { Temperature = 0.2 },
+        cancellationToken: cancellationToken);
+
+    return Results.Ok(response[0].Content);
+});
+```
+
+Для plugins/tools донастройте созданный `Kernel` в том же вызове:
+
+```csharp
+builder.Services.AddGigaChatSemanticKernel(options =>
+{
+    options.ModelIdFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.Model;
+    options.ConfigureKernel = (_, kernel) =>
+        kernel.Plugins.AddFromType<ReleasePlugin>("release");
+});
+```
+
+Если нужен keyed chat service, задайте `options.ServiceId`. По умолчанию
+регистрируются обычные `Kernel` и `IChatCompletionService`.
+
+## Быстрый старт без DI
+
+```csharp
+using GigaChat.Net;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+var kernel = Kernel.CreateBuilder()
+    .AddGigaChatChatCompletion(new Settings
+    {
+        Credentials = Environment.GetEnvironmentVariable("GIGACHAT_CREDENTIALS"),
+        Scope = "GIGACHAT_API_PERS",
+        Model = "GigaChat"
+    })
+    .Build();
+
+var chat = kernel.Services.GetRequiredService<IChatCompletionService>();
+ChatHistory history =
+[
+    new ChatMessageContent(AuthorRole.System, "Ты полезный ассистент. Отвечай кратко."),
+    new ChatMessageContent(AuthorRole.User, "Составь план релиза SDK.")
+];
+
+var response = await chat.GetChatMessageContentsAsync(
+    history,
+    new GigaChatPromptExecutionSettings
+    {
+        Temperature = 0.2,
+        MaxTokens = 700
+    });
+
+Console.WriteLine(response[0].Content);
+```
+
+Минимальная конфигурация через окружение:
+
+```bash
+export GIGACHAT_CREDENTIALS="<authorization-key>"
+export GIGACHAT_SCOPE="GIGACHAT_API_PERS"
+export GIGACHAT_MODEL="GigaChat"
+```
+
+Можно передать и готовый `IGigaChatClient`, если в приложении уже настроены
+transport, retries, сертификаты или общая авторизация:
+
+```csharp
+using var client = new GigaChatClient(new Settings
+{
+    Credentials = Environment.GetEnvironmentVariable("GIGACHAT_CREDENTIALS"),
+    MaxRetries = 3,
+    RetryBackoffFactor = 0.5
+});
+
+var kernel = Kernel.CreateBuilder()
+    .AddGigaChatChatCompletion(
+        client,
+        serviceId: "gigachat",
+        modelId: "GigaChat",
+        endpoint: "https://gigachat.devices.sberbank.ru/api/v1")
+    .Build();
+```
+
+## Plugins/tools
+
+Semantic Kernel plugins становятся GigaChat functions. Для автоматического вызова
+plugins включите `FunctionChoiceBehavior.Auto()` и передайте `kernel` в chat call.
+
+```csharp
+using System.ComponentModel;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+var kernel = Kernel.CreateBuilder()
+    .AddGigaChatChatCompletion(settings)
+    .Build();
+
+kernel.Plugins.AddFromObject(new ReleasePlugin(), "release");
+
+var result = await chat.GetChatMessageContentsAsync(
+    [
+        new ChatMessageContent(AuthorRole.System, "Используй release tools перед ответом."),
+        new ChatMessageContent(AuthorRole.User, "Проверь статус релиза semantic-kernel.")
+    ],
+    new GigaChatPromptExecutionSettings
+    {
+        FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+        MaxToolCalls = 4,
+        Temperature = 0.1
+    },
+    kernel);
+
+Console.WriteLine(result[0].Content);
+
+public sealed class ReleasePlugin
+{
+    [KernelFunction("get_ci_status")]
+    [Description("Returns current CI status for a branch.")]
+    public string GetCiStatus([Description("Branch name.")] string branch) =>
+        $"{branch}: build and tests are expected to pass";
+}
+```
+
+Имена GigaChat functions формируются стабильно как `Plugin_Function`, например
+`release_get_ci_status`. Результаты tool calls добавляются обратно в историю как
+GigaChat `function` messages. По умолчанию один completion может выполнить до
+`MaxToolCalls = 8` вызовов, чтобы избежать бесконечного цикла.
+
+## Agents
+
+`ChatCompletionAgent` использует тот же `IChatCompletionService`. Чтобы агент мог
+вызывать plugins, задайте `FunctionChoiceBehavior.Auto()` в `Agent.Arguments`.
+
+```csharp
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+
+ChatCompletionAgent agent = new()
+{
+    Name = "GigaChatReleaseAgent",
+    Instructions = "Ты инженерный ассистент. Проверяй release risks и отвечай по делу.",
+    Kernel = kernel,
+    Arguments = new KernelArguments(new GigaChatPromptExecutionSettings
+    {
+        Temperature = 0.2,
+        MaxTokens = 800,
+        FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+        MaxToolCalls = 4
+    })
+};
+
+await foreach (var response in agent.InvokeAsync("Составь чеклист релиза SDK."))
+{
+    Console.WriteLine(response.Message.Content);
+}
+```
+
+## Streaming
+
+Text streaming без tools идет напрямую через GigaChat streaming API:
+
+```csharp
+await foreach (var chunk in chat.GetStreamingChatMessageContentsAsync(
+                   history,
+                   new GigaChatPromptExecutionSettings
+                   {
+                       Temperature = 0.1,
+                       MaxTokens = 300
+                   }))
+{
+    Console.Write(chunk.Content);
+}
+```
+
+Если включен `FunctionChoiceBehavior.Auto()`, preview-адаптер выполняет tool loop
+через обычный chat completion и возвращает финальный ответ как streaming content.
+Так streaming API остается совместимым с agent/tool сценариями.
+
+## Structured output
+
+GigaChat structured output передается через provider-specific поле
+`response_format` в `AdditionalFields`.
+
+```csharp
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GigaChat.Net.Models;
+using GigaChat.Net.SemanticKernel;
+
+var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+var schema = JsonSchemaResponseFormat.FromType<ReleasePlan>(jsonOptions: jsonOptions);
+
+var result = await chat.GetChatMessageContentsAsync(
+    history,
+    new GigaChatPromptExecutionSettings
+    {
+        Temperature = 0.1,
+        MaxTokens = 900,
+        AdditionalFields = new Dictionary<string, object?>
+        {
+            ["response_format"] = schema
+        }
+    });
+
+var plan = JsonSerializer.Deserialize<ReleasePlan>(result[0].Content!, jsonOptions);
+
+/// <summary>
+/// Structured release plan returned by GigaChat through Semantic Kernel response_format.
+/// </summary>
+public sealed record ReleasePlan
+{
+    /// <summary>
+    /// Short human-readable release summary.
+    /// </summary>
+    [Description("Short human-readable release summary.")]
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Overall release risk level.
+    /// </summary>
+    [Description("Overall release risk level.")]
+    [JsonPropertyName("risk_level")]
+    public required string RiskLevel { get; init; }
+
+    /// <summary>
+    /// Concrete release tasks that should be completed.
+    /// </summary>
+    [Description("Concrete release tasks that should be completed.")]
+    [JsonPropertyName("tasks")]
+    public required IReadOnlyList<string> Tasks { get; init; }
+}
+```
+
+`JsonSchemaResponseFormat.FromType<T>()` строит JSON Schema из C# DTO. XML
+`<summary>` и `DescriptionAttribute` помогают держать схему понятной людям и модели.
+
+## GigaChatPromptExecutionSettings
+
+`GigaChatPromptExecutionSettings` расширяет стандартные `PromptExecutionSettings`.
+
+| Свойство | Назначение |
+| --- | --- |
+| `ModelId` | Модель для конкретного SK вызова. |
+| `Temperature` | Степень вариативности ответа. |
+| `TopP` | Nucleus sampling. |
+| `MaxTokens` | Максимальное число completion tokens. |
+| `RepetitionPenalty` | Штраф за повторения. |
+| `ProfanityCheck` | Фильтрация ненормативной лексики. |
+| `Flags` | Дополнительные GigaChat feature flags. |
+| `ReasoningEffort` | Reasoning effort, если поддерживается моделью. |
+| `Headers` | Per-call `GigaChatRequestHeaders`. |
+| `FunctionChoiceBehavior` | SK function/tool choice behavior. |
+| `MaxToolCalls` | Лимит auto tool calls, default `8`. |
+| `AdditionalFields` | Дополнительные поля JSON payload, например `response_format`. |
+
+```csharp
+var settings = new GigaChatPromptExecutionSettings
+{
+    ModelId = "GigaChat-Pro",
+    Temperature = 0.2,
+    TopP = 0.9,
+    MaxTokens = 512,
+    RepetitionPenalty = 1.05,
+    ProfanityCheck = true,
+    Headers = new GigaChatRequestHeaders
+    {
+        RequestId = Guid.NewGuid().ToString("N"),
+        SessionId = "semantic-kernel-demo"
+    }
+};
+```
+
+## ReAct агент
+
+`GigaChatReActAgent` реализует Reason + Act паттерн через fluent builder API.
+Агент автоматически запускает tool loop, сохраняет шаги выполнения и поддерживает
+многоходовые диалоги через `IGigaChatAgentThreadStore`.
+
+```csharp
+using GigaChat.Net.SemanticKernel;
+
+var agent = GigaChatReActAgent.Create(builder =>
+{
+    builder.UseClient(client);
+    builder.WithInstructions(GigaChatReActInstructions.DefaultRussian);
+    builder.AddPlugin(new ReleasePlugin(), "release");
+    builder.WithMaxToolCalls(6);
+    builder.UseThreadStore(new InMemoryGigaChatAgentThreadStore());
+});
+
+// Один запрос
+var result = await agent.InvokeAsync("Проверь статус релиза SDK.");
+Console.WriteLine(result.Messages[0].Content);
+
+// Многоходовой диалог
+var r1 = await agent.InvokeAsync("Что нужно для релиза?", threadId: "session-1");
+var r2 = await agent.InvokeAsync("Отлично, запускай.", threadId: "session-1");
+
+// Трассировка шагов
+var traced = await agent.Kernel.Services
+    .GetRequiredService<GigaChatChatCompletionService>()
+    .RunWithStepsAsync([new ChatMessageContent(AuthorRole.User, "go")], kernel: agent.Kernel);
+foreach (var step in traced.Steps)
+    Console.WriteLine($"[{step.GetType().Name}] {step.ToolName} +{step.LatencyMs}ms");
+```
+
+Готовые шаблоны системных инструкций доступны в `GigaChatReActInstructions`:
+`DefaultRussian`, `DefaultEnglish`, `ToolFirst`, `ReadOnlyResearch`, `SupportAgent`.
+
+Настройки безопасности через `GigaChatToolSafetyOptions`:
+- `ErrorBehavior` — `FailFast` (по умолчанию) или `ReturnObservation`
+- `MaxOutputLength` — обрезка длинных tool outputs
+- `AllowedPlugins` — allowlist плагинов по имени
+
+## Ограничения
+
+- Адаптер покрывает chat completion и streaming через `IChatCompletionService`.
+- `FunctionChoiceBehavior.Auto()` поддержан для Kernel plugins/tools.
+- Streaming + tools работает через buffered fallback: выполняется tool loop,
+  затем возвращается финальный streaming content.
+- Поддерживаются text content, `FunctionCallContent` и `FunctionResultContent`.
+  Multimodal SK items явно отклоняются.
+- GigaChat-specific возможности передаются через `GigaChatPromptExecutionSettings`.
+- Для прямых SDK-возможностей вроде files, assistants, embeddings, token count и
+  `ChatParse<T>()` используйте `IGigaChatClient` из базового пакета `GigaChat.Net`.
+
+## Пример
+
+Расширенный пример находится в репозитории:
+
+```bash
+dotnet run --project examples/GigaChat.SemanticKernel.Example/GigaChat.SemanticKernel.Example.csproj -- "Составь чеклист релиза SDK"
+```
+
+Пример показывает chat completion, streaming, structured output, plugins/tools,
+`ChatCompletionAgent` и несколько прямых SDK probes.
+
+## Документация
+
+Полная документация, исходный код и примеры находятся в репозитории:
+
+https://github.com/h0tnanny/GigaChat-Net

--- a/examples/GigaChat.AspNetCore.Example/GigaChat.AspNetCore.Example.csproj
+++ b/examples/GigaChat.AspNetCore.Example/GigaChat.AspNetCore.Example.csproj
@@ -2,6 +2,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\GigaChat.Net.AspNetCore\GigaChat.Net.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\GigaChat.Net.SemanticKernel\GigaChat.Net.SemanticKernel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.76.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.76.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/examples/GigaChat.AspNetCore.Example/Program.cs
+++ b/examples/GigaChat.AspNetCore.Example/Program.cs
@@ -1,9 +1,28 @@
+using System.ComponentModel;
+using System.Text.Json;
 using GigaChat.Net;
 using GigaChat.Net.AspNetCore;
+using GigaChat.Net.Models;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddGigaChat(builder.Configuration);
+builder.Services.AddGigaChatSemanticKernel(options =>
+{
+    options.ModelIdFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.Model;
+    options.EndpointFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.BaseUrl;
+    options.ConfigureKernel = (provider, kernel) =>
+    {
+        var model = provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.Model ?? "GigaChat";
+        kernel.Plugins.AddFromObject(new ReleasePlugin(model), "release");
+    };
+});
 
 // Optional: context values can come from headers, query, claims, route values, or your own services.
 // With AllowModelOverrideFromHeader enabled, X-GigaChat-Model is copied automatically.
@@ -40,7 +59,16 @@ app.UseGigaChatContext();
 app.MapGet("/", () => Results.Ok(new
 {
     Name = "GigaChat ASP.NET Core example",
-    Endpoints = new[] { "POST /chat", "GET /models" }
+    Endpoints = new[]
+    {
+        "POST /chat",
+        "GET /models",
+        "POST /semantic-kernel/chat",
+        "POST /semantic-kernel/stream",
+        "POST /semantic-kernel/structured-output",
+        "POST /semantic-kernel/tools",
+        "POST /semantic-kernel/agent"
+    }
 }));
 
 app.MapPost("/chat", async (
@@ -51,15 +79,10 @@ app.MapPost("/chat", async (
     if (string.IsNullOrWhiteSpace(request.Message))
         return Results.BadRequest(new { Error = "Message is required." });
 
-    var headers = request.RequestId is null && request.SessionId is null
-        ? null
-        : new GigaChatRequestHeaders
-        {
-            RequestId = request.RequestId,
-            SessionId = request.SessionId
-        };
-
-    var response = await client.ChatAsync(request.Message, headers, cancellationToken);
+    var response = await client.ChatAsync(
+        request.Message,
+        CreateRequestHeaders(request),
+        cancellationToken);
     var message = response.Choices.FirstOrDefault()?.Message.Content;
 
     return Results.Ok(new ChatResponse(message ?? string.Empty));
@@ -71,10 +94,255 @@ app.MapGet("/models", async (IGigaChatClient client, CancellationToken cancellat
     return Results.Ok(models.Data.Select(model => new ModelResponse(model.Id, model.OwnedBy)));
 });
 
+app.MapPost("/semantic-kernel/chat", async (
+    ChatRequest request,
+    IChatCompletionService chat,
+    CancellationToken cancellationToken) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Message))
+        return Results.BadRequest(new { Error = "Message is required." });
+
+    var response = await chat.GetChatMessageContentsAsync(
+        CreateHistory(
+            "Ты ASP.NET Core ассистент. Отвечай кратко, структурно и практически.",
+            request.Message),
+        new GigaChatPromptExecutionSettings
+        {
+            Temperature = request.Temperature ?? 0.2,
+            MaxTokens = request.MaxTokens ?? 700,
+            Headers = CreateRequestHeaders(request)
+        },
+        cancellationToken: cancellationToken);
+
+    return Results.Ok(new ChatResponse(response[0].Content ?? string.Empty));
+});
+
+app.MapPost("/semantic-kernel/stream", async (
+    ChatRequest request,
+    HttpResponse response,
+    IChatCompletionService chat,
+    CancellationToken cancellationToken) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Message))
+    {
+        response.StatusCode = StatusCodes.Status400BadRequest;
+        await response.WriteAsJsonAsync(new { Error = "Message is required." }, cancellationToken);
+        return;
+    }
+
+    response.ContentType = "text/plain; charset=utf-8";
+    await foreach (var chunk in chat.GetStreamingChatMessageContentsAsync(
+                       CreateHistory(
+                           "Ты ASP.NET Core ассистент. Отвечай одним коротким абзацем.",
+                           request.Message),
+                       new GigaChatPromptExecutionSettings
+                       {
+                           Temperature = request.Temperature ?? 0.1,
+                           MaxTokens = request.MaxTokens ?? 300,
+                           Headers = CreateRequestHeaders(request)
+                       },
+                       cancellationToken: cancellationToken))
+    {
+        if (!string.IsNullOrEmpty(chunk.Content))
+        {
+            await response.WriteAsync(chunk.Content, cancellationToken);
+            await response.Body.FlushAsync(cancellationToken);
+        }
+    }
+});
+
+app.MapPost("/semantic-kernel/structured-output", async (
+    ChatRequest request,
+    IChatCompletionService chat,
+    CancellationToken cancellationToken) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Message))
+        return Results.BadRequest(new { Error = "Message is required." });
+
+    var jsonOptions = CreateJsonOptions();
+    var schema = JsonSchemaResponseFormat.FromType<ReleasePlan>(jsonOptions: jsonOptions);
+    var response = await chat.GetChatMessageContentsAsync(
+        CreateHistory(
+            "Верни только JSON, который строго соответствует переданной JSON Schema.",
+            $"Собери structured release plan для задачи: {request.Message}"),
+        new GigaChatPromptExecutionSettings
+        {
+            Temperature = request.Temperature ?? 0.1,
+            MaxTokens = request.MaxTokens ?? 900,
+            Headers = CreateRequestHeaders(request),
+            AdditionalFields = new Dictionary<string, object?>
+            {
+                ["response_format"] = schema
+            }
+        },
+        cancellationToken: cancellationToken);
+
+    var plan = JsonSerializer.Deserialize<ReleasePlan>(response[0].Content ?? "{}", jsonOptions)
+        ?? throw new InvalidOperationException("Structured response was empty.");
+
+    return Results.Ok(plan);
+});
+
+app.MapPost("/semantic-kernel/tools", async (
+    ChatRequest request,
+    Kernel kernel,
+    IChatCompletionService chat,
+    CancellationToken cancellationToken) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Message))
+        return Results.BadRequest(new { Error = "Message is required." });
+
+    var response = await chat.GetChatMessageContentsAsync(
+        CreateHistory(
+            "Ты release coordinator. Используй release tools перед финальным ответом.",
+            request.Message),
+        new GigaChatPromptExecutionSettings
+        {
+            Temperature = request.Temperature ?? 0.1,
+            MaxTokens = request.MaxTokens ?? 800,
+            Headers = CreateRequestHeaders(request),
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+            MaxToolCalls = 4
+        },
+        kernel,
+        cancellationToken);
+
+    return Results.Ok(new ChatResponse(
+        response[0].Content ?? string.Empty,
+        response[0].Metadata?.TryGetValue("function_calls", out var calls) == true ? calls : null));
+});
+
+app.MapPost("/semantic-kernel/agent", async (
+    ChatRequest request,
+    Kernel kernel,
+    CancellationToken cancellationToken) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Message))
+        return Results.BadRequest(new { Error = "Message is required." });
+
+    ChatCompletionAgent agent = new()
+    {
+        Name = "AspNetGigaChatAgent",
+        Instructions = """
+            Ты ASP.NET Core агент для .NET SDK.
+            Проверяй release facts через tools и отвечай коротко, с конкретными следующими действиями.
+            """,
+        Kernel = kernel,
+        Arguments = new KernelArguments(new GigaChatPromptExecutionSettings
+        {
+            Temperature = request.Temperature ?? 0.2,
+            MaxTokens = request.MaxTokens ?? 800,
+            Headers = CreateRequestHeaders(request),
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+            MaxToolCalls = 4
+        })
+    };
+
+    var messages = new List<string>();
+    await foreach (var item in agent.InvokeAsync(request.Message, cancellationToken: cancellationToken))
+        messages.Add(item.Message.Content ?? string.Empty);
+
+    return Results.Ok(new ChatResponse(string.Join(Environment.NewLine, messages)));
+});
+
 app.Run();
 
-public sealed record ChatRequest(string Message, string? RequestId = null, string? SessionId = null);
+static ChatHistory CreateHistory(string system, string user) =>
+[
+    new ChatMessageContent(AuthorRole.System, system),
+    new ChatMessageContent(AuthorRole.User, user)
+];
 
-public sealed record ChatResponse(string Message);
+static GigaChatRequestHeaders? CreateRequestHeaders(ChatRequest request)
+{
+    return request.RequestId is null && request.SessionId is null
+        ? null
+        : new GigaChatRequestHeaders
+        {
+            RequestId = request.RequestId,
+            SessionId = request.SessionId
+        };
+}
+
+static JsonSerializerOptions CreateJsonOptions() =>
+    new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+public sealed record ChatRequest(
+    string Message,
+    string? RequestId = null,
+    string? SessionId = null,
+    double? Temperature = null,
+    int? MaxTokens = null);
+
+public sealed record ChatResponse(string Message, object? ToolCalls = null);
 
 public sealed record ModelResponse(string Id, string OwnedBy);
+
+/// <summary>
+/// Structured release plan returned by GigaChat through Semantic Kernel response_format.
+/// </summary>
+public sealed record ReleasePlan
+{
+    /// <summary>
+    /// Short human-readable release summary.
+    /// </summary>
+    [Description("Short human-readable release summary.")]
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Overall release risk level, for example low, medium, or high.
+    /// </summary>
+    [Description("Overall release risk level, for example low, medium, or high.")]
+    public required string RiskLevel { get; init; }
+
+    /// <summary>
+    /// Concrete release tasks that should be completed.
+    /// </summary>
+    [Description("Concrete release tasks that should be completed.")]
+    public required IReadOnlyList<string> Tasks { get; init; }
+}
+
+/// <summary>
+/// Local Semantic Kernel plugin exposed to ASP.NET endpoints as GigaChat functions.
+/// </summary>
+public sealed class ReleasePlugin(string model)
+{
+    /// <summary>
+    /// Returns the package version that the ASP.NET example should mention in release answers.
+    /// </summary>
+    [KernelFunction("get_package_version")]
+    [Description("Returns the current package version for the Semantic Kernel adapter.")]
+    public string GetPackageVersion(
+        [Description("NuGet package id to inspect.")] string packageId = "GigaChat.Net.SemanticKernel")
+    {
+        return packageId.Equals("GigaChat.Net.SemanticKernel", StringComparison.OrdinalIgnoreCase)
+            ? "0.1.0-preview.semantic-kernel"
+            : "unknown";
+    }
+
+    /// <summary>
+    /// Returns local CI expectations for the release branch.
+    /// </summary>
+    [KernelFunction("get_ci_status")]
+    [Description("Returns the latest local CI status for a release branch.")]
+    public string GetCiStatus(
+        [Description("Branch name to inspect.")] string branch = "semantic-kernel")
+    {
+        return JsonSerializer.Serialize(
+            new
+            {
+                branch,
+                model,
+                build = "expected: dotnet build",
+                tests = "expected: dotnet test",
+                package = "expected: dotnet pack"
+            },
+            new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+            });
+    }
+}

--- a/examples/GigaChat.AspNetCore.Example/README.md
+++ b/examples/GigaChat.AspNetCore.Example/README.md
@@ -1,0 +1,120 @@
+# GigaChat.AspNetCore.Example
+
+ASP.NET Core пример показывает два уровня интеграции:
+
+- `GigaChat.Net.AspNetCore`: DI-регистрация `IGigaChatClient`, request context middleware, per-request headers;
+- `GigaChat.Net.SemanticKernel`: `AddGigaChatSemanticKernel(...)`, `IChatCompletionService`, streaming, structured output, Semantic Kernel plugins/tools и `ChatCompletionAgent`.
+
+## Configuration
+
+Перед запуском задайте авторизацию через `appsettings.json`, user secrets или переменные окружения:
+
+```bash
+export GIGACHAT__CREDENTIALS="<authorization-key>"
+export GIGACHAT__SCOPE="GIGACHAT_API_PERS"
+export GIGACHAT__MODEL="GigaChat"
+```
+
+`appsettings.json` уже включает безопасные defaults:
+
+```json
+{
+  "GigaChat": {
+    "Scope": "GIGACHAT_API_PERS",
+    "AllowModelOverrideFromHeader": true,
+    "MaxRetries": 3,
+    "RetryOnStatusCodes": [429, 500, 502, 503, 504]
+  }
+}
+```
+
+## Run
+
+```bash
+dotnet run --project examples/GigaChat.AspNetCore.Example/GigaChat.AspNetCore.Example.csproj
+```
+
+По умолчанию Kestrel выведет URL в консоль, например `http://localhost:5000`.
+
+## Basic SDK endpoint
+
+```bash
+curl -X POST http://localhost:5000/chat \
+  -H "Content-Type: application/json" \
+  -H "X-Request-ID: demo-request" \
+  -d "{\"message\":\"Составь короткий план релиза SDK\"}"
+```
+
+## Semantic Kernel chat
+
+```bash
+curl -X POST http://localhost:5000/semantic-kernel/chat \
+  -H "Content-Type: application/json" \
+  -d "{\"message\":\"Составь чеклист релиза Semantic Kernel preview\",\"temperature\":0.2,\"maxTokens\":700}"
+```
+
+## Semantic Kernel streaming
+
+```bash
+curl -N -X POST http://localhost:5000/semantic-kernel/stream \
+  -H "Content-Type: application/json" \
+  -d "{\"message\":\"Сделай короткий TL;DR по релизу Semantic Kernel adapter\"}"
+```
+
+## Structured output
+
+```bash
+curl -X POST http://localhost:5000/semantic-kernel/structured-output \
+  -H "Content-Type: application/json" \
+  -d "{\"message\":\"Подготовить preview NuGet release\"}"
+```
+
+Ответ будет JSON по DTO `ReleasePlan`.
+
+## Semantic Kernel plugins/tools
+
+```bash
+curl -X POST http://localhost:5000/semantic-kernel/tools \
+  -H "Content-Type: application/json" \
+  -d "{\"message\":\"Проверь статус релиза semantic-kernel и назови следующие действия\"}"
+```
+
+Endpoint регистрирует локальный `ReleasePlugin` и включает `FunctionChoiceBehavior.Auto()`.
+GigaChat получает tools как функции `release_get_package_version` и `release_get_ci_status`.
+
+## ChatCompletionAgent
+
+```bash
+curl -X POST http://localhost:5000/semantic-kernel/agent \
+  -H "Content-Type: application/json" \
+  -d "{\"message\":\"Собери финальный release brief для Semantic Kernel preview\"}"
+```
+
+Agent использует тот же Kernel, GigaChat-backed `IChatCompletionService` и локальный `ReleasePlugin`.
+
+## Semantic Kernel registration
+
+Пример использует существующую SDK-регистрацию и добавляет Semantic Kernel поверх нее:
+
+```csharp
+builder.Services.AddGigaChat(builder.Configuration);
+builder.Services.AddGigaChatSemanticKernel(options =>
+{
+    options.ModelIdFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.Model;
+    options.EndpointFactory = provider => provider.GetRequiredService<IOptions<GigaChatOptions>>().Value.BaseUrl;
+    options.ConfigureKernel = (_, kernel) =>
+        kernel.Plugins.AddFromObject(new ReleasePlugin("GigaChat"), "release");
+});
+```
+
+## Request context
+
+`UseGigaChatContext()` копирует request metadata из headers:
+
+- `X-Request-ID`
+- `X-Session-ID`
+- `X-Trace-ID`
+- `X-Client-ID`
+- `X-GigaChat-Model`
+
+Также пример поддерживает query параметры `requestId` и `sessionId`.

--- a/examples/GigaChat.SemanticKernel.Example/GigaChat.SemanticKernel.Example.csproj
+++ b/examples/GigaChat.SemanticKernel.Example/GigaChat.SemanticKernel.Example.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.76.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.76.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GigaChat.Net.SemanticKernel\GigaChat.Net.SemanticKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/GigaChat.SemanticKernel.Example/Program.cs
+++ b/examples/GigaChat.SemanticKernel.Example/Program.cs
@@ -1,0 +1,488 @@
+using System.Globalization;
+using System.ComponentModel;
+using System.Text.Json;
+using GigaChat.Net;
+using GigaChat.Net.Models;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+var prompt = args.Length > 0
+    ? string.Join(' ', args)
+    : "Составь короткий чеклист для релиза .NET SDK.";
+
+var settings = CreateSettings();
+EnsureAuthConfigured(settings);
+PrintConfiguration(settings);
+
+using var client = new GigaChatClient(settings);
+var kernel = Kernel.CreateBuilder()
+    .AddGigaChatChatCompletion(
+        client,
+        modelId: settings.Model,
+        endpoint: settings.BaseUrl)
+    .Build();
+kernel.Plugins.AddFromObject(new ReleasePlugin(settings.Model ?? "GigaChat"), "release");
+
+var chatService = kernel.Services.GetRequiredService<IChatCompletionService>();
+var requestHeaders = CreateRequestHeaders();
+
+await RunSectionAsync(
+    "Semantic Kernel chat completion",
+    async () => await RunChatCompletionAsync(chatService, prompt, requestHeaders, cts.Token));
+
+await RunSectionAsync(
+    "Semantic Kernel streaming",
+    async () => await RunStreamingAsync(chatService, prompt, requestHeaders, cts.Token));
+
+await RunSectionAsync(
+    "Semantic Kernel plugins/tools",
+    async () => await RunPluginToolsAsync(chatService, kernel, prompt, requestHeaders, cts.Token));
+
+await RunSectionAsync(
+    "Semantic Kernel agent with tools",
+    async () => await RunAgentAsync(kernel, prompt, requestHeaders, cts.Token));
+
+await RunSectionAsync(
+    "Structured output",
+    async () => await RunStructuredOutputAsync(chatService, prompt, requestHeaders, cts.Token));
+
+await RunSectionAsync(
+    "GigaChat ReAct agent (GigaChatReActAgent)",
+    async () => await RunReActAgentAsync(client, settings.Model, prompt, cts.Token));
+
+await RunSectionAsync(
+    "GigaChat SDK probes",
+    async () => await RunSdkProbesAsync(client, prompt, settings.Model, requestHeaders, cts.Token));
+
+static Settings CreateSettings()
+{
+    return new Settings
+    {
+        Scope = Environment.GetEnvironmentVariable("GIGACHAT_SCOPE") ?? "GIGACHAT_API_PERS",
+        Model = Environment.GetEnvironmentVariable("GIGACHAT_MODEL") ?? "GigaChat",
+        MaxRetries = GetInt("GIGACHAT_MAX_RETRIES", 3),
+        RetryBackoffFactor = GetDouble("GIGACHAT_RETRY_BACKOFF_FACTOR", 0.5)
+    };
+}
+
+static async Task RunPluginToolsAsync(
+    IChatCompletionService chatService,
+    Kernel kernel,
+    string prompt,
+    GigaChatRequestHeaders? requestHeaders,
+    CancellationToken cancellationToken)
+{
+    ChatHistory history =
+    [
+        new ChatMessageContent(
+            AuthorRole.System,
+            """
+            Ты release coordinator. Используй доступные release tools перед финальным ответом.
+            Сначала проверь версию пакета и статус проверок, затем дай короткий план действий.
+            """),
+        new ChatMessageContent(AuthorRole.User, $"Подготовь релизный статус для задачи: {prompt}")
+    ];
+
+    var messages = await chatService.GetChatMessageContentsAsync(
+        history,
+        new GigaChatPromptExecutionSettings
+        {
+            Temperature = 0.1,
+            MaxTokens = 800,
+            Headers = requestHeaders,
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+            MaxToolCalls = 4
+        },
+        kernel,
+        cancellationToken);
+
+    foreach (var message in messages)
+    {
+        Console.WriteLine(message.Content);
+        if (message.Metadata?.TryGetValue("function_calls", out var calls) == true)
+            Console.WriteLine($"Tool calls: {JsonSerializer.Serialize(calls, CreateStructuredJsonOptions())}");
+    }
+}
+
+static void EnsureAuthConfigured(Settings settings)
+{
+    if (!string.IsNullOrWhiteSpace(settings.Credentials) ||
+        !string.IsNullOrWhiteSpace(settings.AccessToken))
+    {
+        return;
+    }
+
+    throw new InvalidOperationException(
+        "Set GIGACHAT_CREDENTIALS or GIGACHAT_ACCESS_TOKEN before running the example.");
+}
+
+static void PrintConfiguration(Settings settings)
+{
+    Console.WriteLine("GigaChat Semantic Kernel showcase");
+    Console.WriteLine($"Base URL: {settings.BaseUrl}");
+    Console.WriteLine($"Auth URL: {settings.AuthUrl}");
+    Console.WriteLine($"Scope: {settings.Scope}");
+    Console.WriteLine($"Model: {settings.Model}");
+    Console.WriteLine($"Auth: {(string.IsNullOrWhiteSpace(settings.AccessToken) ? "OAuth credentials" : "access token")}");
+    Console.WriteLine($"Retries: {settings.MaxRetries}, backoff: {settings.RetryBackoffFactor.ToString(CultureInfo.InvariantCulture)}");
+
+    if (!string.IsNullOrWhiteSpace(settings.CaBundleFile))
+        Console.WriteLine($"CA bundle: {settings.CaBundleFile}");
+}
+
+static GigaChatRequestHeaders? CreateRequestHeaders()
+{
+    var headers = new GigaChatRequestHeaders
+    {
+        ClientId = Environment.GetEnvironmentVariable("GIGACHAT_CLIENT_ID"),
+        RequestId = Environment.GetEnvironmentVariable("GIGACHAT_REQUEST_ID") ?? Guid.NewGuid().ToString("N"),
+        SessionId = Environment.GetEnvironmentVariable("GIGACHAT_SESSION_ID"),
+        ServiceId = Environment.GetEnvironmentVariable("GIGACHAT_SERVICE_ID"),
+        OperationId = Environment.GetEnvironmentVariable("GIGACHAT_OPERATION_ID"),
+        TraceId = Environment.GetEnvironmentVariable("GIGACHAT_TRACE_ID"),
+        AgentId = Environment.GetEnvironmentVariable("GIGACHAT_AGENT_ID")
+    };
+
+    return HasAnyHeader(headers) ? headers : null;
+}
+
+static bool HasAnyHeader(GigaChatRequestHeaders headers)
+{
+    return !string.IsNullOrWhiteSpace(headers.ClientId) ||
+           !string.IsNullOrWhiteSpace(headers.RequestId) ||
+           !string.IsNullOrWhiteSpace(headers.SessionId) ||
+           !string.IsNullOrWhiteSpace(headers.ServiceId) ||
+           !string.IsNullOrWhiteSpace(headers.OperationId) ||
+           !string.IsNullOrWhiteSpace(headers.TraceId) ||
+           !string.IsNullOrWhiteSpace(headers.AgentId);
+}
+
+static async Task RunChatCompletionAsync(
+    IChatCompletionService chatService,
+    string prompt,
+    GigaChatRequestHeaders? requestHeaders,
+    CancellationToken cancellationToken)
+{
+    ChatHistory history =
+    [
+        new ChatMessageContent(
+            AuthorRole.System,
+            "Ты senior .NET engineer. Отвечай кратко, структурно и практически."),
+        new ChatMessageContent(AuthorRole.User, prompt)
+    ];
+
+    var messages = await chatService.GetChatMessageContentsAsync(
+        history,
+        new GigaChatPromptExecutionSettings
+        {
+            Temperature = 0.2,
+            TopP = 0.9,
+            MaxTokens = 700,
+            RepetitionPenalty = 1.05,
+            ProfanityCheck = true,
+            Headers = requestHeaders,
+            ReasoningEffort = Environment.GetEnvironmentVariable("GIGACHAT_REASONING_EFFORT")
+        },
+        cancellationToken: cancellationToken);
+
+    foreach (var message in messages)
+    {
+        Console.WriteLine(message.Content);
+        PrintUsage(message.Metadata);
+    }
+}
+
+static async Task RunStreamingAsync(
+    IChatCompletionService chatService,
+    string prompt,
+    GigaChatRequestHeaders? requestHeaders,
+    CancellationToken cancellationToken)
+{
+    ChatHistory history =
+    [
+        new ChatMessageContent(
+            AuthorRole.System,
+            "Отвечай как технический редактор: сжато, но без потери смысла."),
+        new ChatMessageContent(AuthorRole.User, $"Сделай TL;DR для задачи: {prompt}")
+    ];
+
+    await foreach (var chunk in chatService.GetStreamingChatMessageContentsAsync(
+                       history,
+                       new GigaChatPromptExecutionSettings
+                       {
+                           Temperature = 0.1,
+                           MaxTokens = 300,
+                           Headers = requestHeaders
+                       },
+                       cancellationToken: cancellationToken))
+    {
+        Console.Write(chunk.Content);
+    }
+
+    Console.WriteLine();
+}
+
+static async Task RunAgentAsync(
+    Kernel kernel,
+    string prompt,
+    GigaChatRequestHeaders? requestHeaders,
+    CancellationToken cancellationToken)
+{
+    ChatCompletionAgent agent = new()
+    {
+        Name = "GigaChatReleaseAgent",
+        Instructions = """
+            Ты инженерный ассистент для .NET SDK.
+            Проверяй релизные риски, предлагай короткие действия и не уходи в общие рассуждения.
+            """,
+        Kernel = kernel,
+        Arguments = new KernelArguments(new GigaChatPromptExecutionSettings
+        {
+            Temperature = 0.2,
+            MaxTokens = 800,
+            Headers = requestHeaders,
+            FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+            MaxToolCalls = 4
+        })
+    };
+
+    await foreach (var response in agent.InvokeAsync(prompt, cancellationToken: cancellationToken))
+    {
+        Console.WriteLine(response.Message.Content);
+    }
+}
+
+static async Task RunStructuredOutputAsync(
+    IChatCompletionService chatService,
+    string prompt,
+    GigaChatRequestHeaders? requestHeaders,
+    CancellationToken cancellationToken)
+{
+    var jsonOptions = CreateStructuredJsonOptions();
+    var schema = JsonSchemaResponseFormat.FromType<ReleasePlan>(jsonOptions: jsonOptions);
+    ChatHistory history =
+    [
+        new ChatMessageContent(
+            AuthorRole.System,
+            "Верни только JSON, который строго соответствует переданной JSON Schema."),
+        new ChatMessageContent(AuthorRole.User, $"Собери структурированный план релиза для задачи: {prompt}")
+    ];
+
+    var messages = await chatService.GetChatMessageContentsAsync(
+        history,
+        new GigaChatPromptExecutionSettings
+        {
+            Temperature = 0.1,
+            MaxTokens = 900,
+            Headers = requestHeaders,
+            AdditionalFields = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["response_format"] = schema
+            }
+        },
+        cancellationToken: cancellationToken);
+
+    var rawJson = messages[0].Content ?? "{}";
+    var skPlan = JsonSerializer.Deserialize<ReleasePlan>(
+            rawJson,
+            jsonOptions)
+        ?? throw new InvalidOperationException("Structured Semantic Kernel response was empty.");
+
+    PrintReleasePlan("Semantic Kernel response_format", skPlan);
+}
+
+static async Task RunReActAgentAsync(
+    IGigaChatClient client,
+    string? modelId,
+    string prompt,
+    CancellationToken cancellationToken)
+{
+    var store = new InMemoryGigaChatAgentThreadStore();
+
+    var agent = GigaChatReActAgent.Create(builder =>
+    {
+        builder.UseClient(client);
+        builder.WithInstructions(GigaChatReActInstructions.DefaultRussian);
+        builder.WithModelId(modelId ?? "GigaChat");
+        builder.WithTemperature(0.1);
+        builder.WithMaxToolCalls(5);
+        builder.WithToolSafety(new GigaChatToolSafetyOptions
+        {
+            ErrorBehavior = GigaChatToolErrorBehavior.ReturnObservation,
+            MaxOutputLength = 2000
+        });
+        builder.UseThreadStore(store);
+        builder.AddPlugin(new ReleasePlugin(modelId ?? "GigaChat"), "release");
+    });
+
+    const string threadId = "react-demo-thread";
+
+    var result1 = await agent.InvokeAsync($"Подготовь релизный статус: {prompt}", threadId, cancellationToken);
+    Console.WriteLine($"Turn 1: {result1.Messages[^1].Content}");
+    Console.WriteLine($"  Steps: {result1.Steps.Count} | LatencyMs (last): {result1.Steps[^1].LatencyMs}");
+
+    var result2 = await agent.InvokeAsync("Есть ли критические проблемы?", threadId, cancellationToken);
+    Console.WriteLine($"Turn 2: {result2.Messages[^1].Content}");
+
+    var thread = await store.LoadAsync(threadId, cancellationToken);
+    Console.WriteLine($"Thread history: {thread!.History.Count} messages, {thread.Steps.Count} total steps");
+}
+
+static async Task RunSdkProbesAsync(
+    IGigaChatClient client,
+    string prompt,
+    string? model,
+    GigaChatRequestHeaders? requestHeaders,
+    CancellationToken cancellationToken)
+{
+    var models = await client.GetModelsAsync(requestHeaders, cancellationToken);
+    Console.WriteLine("Available models: " + string.Join(", ", models.Data.Take(5).Select(item => item.Id)));
+
+    var counts = await client.TokensCountAsync([prompt], model, cancellationToken);
+    var count = counts[0];
+    Console.WriteLine($"Prompt size: {count.Tokens} tokens, {count.Characters} chars");
+
+    var embeddings = await client.EmbeddingsAsync(
+        ["Semantic Kernel adapter for GigaChat SDK"],
+        "Embeddings",
+        requestHeaders,
+        cancellationToken);
+    var vector = embeddings.Data[0].EmbeddingVector;
+    Console.WriteLine($"Embedding model: {embeddings.Model}");
+    Console.WriteLine($"Embedding dimensions: {vector.Count}");
+    Console.WriteLine("Embedding preview: " + string.Join(", ", vector.Take(3).Select(FormatDouble)));
+}
+
+static async Task RunSectionAsync(string title, Func<Task> action)
+{
+    Console.WriteLine();
+    Console.WriteLine($"== {title} ==");
+
+    try
+    {
+        await action();
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"{title} failed: {ex.GetType().Name}: {ex.Message}");
+    }
+}
+
+static void PrintUsage(IReadOnlyDictionary<string, object?>? metadata)
+{
+    if (metadata is null ||
+        !metadata.TryGetValue("usage", out var value) ||
+        value is not Usage usage)
+    {
+        return;
+    }
+
+    Console.WriteLine(
+        $"Usage: prompt={usage.PromptTokens}, completion={usage.CompletionTokens}, total={usage.TotalTokens}");
+}
+
+static int GetInt(string name, int fallback)
+{
+    return int.TryParse(Environment.GetEnvironmentVariable(name), out var value)
+        ? value
+        : fallback;
+}
+
+static double GetDouble(string name, double fallback)
+{
+    return double.TryParse(
+        Environment.GetEnvironmentVariable(name),
+        NumberStyles.Float,
+        CultureInfo.InvariantCulture,
+        out var value)
+        ? value
+        : fallback;
+}
+
+static string FormatDouble(double value) =>
+    value.ToString("0.####", CultureInfo.InvariantCulture);
+
+static JsonSerializerOptions CreateStructuredJsonOptions() =>
+    new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+static void PrintReleasePlan(string label, ReleasePlan plan)
+{
+    Console.WriteLine($"{label}:");
+    Console.WriteLine($"  summary: {plan.Summary}");
+    Console.WriteLine($"  risk: {plan.RiskLevel}");
+    Console.WriteLine($"  tasks: {string.Join("; ", plan.Tasks)}");
+}
+
+/// <summary>
+/// Structured release plan returned by GigaChat through Semantic Kernel response_format.
+/// </summary>
+internal sealed record ReleasePlan
+{
+    /// <summary>
+    /// Short human-readable release summary.
+    /// </summary>
+    [Description("Short human-readable release summary.")]
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Overall release risk level, for example low, medium, or high.
+    /// </summary>
+    [Description("Overall release risk level, for example low, medium, or high.")]
+    public required string RiskLevel { get; init; }
+
+    /// <summary>
+    /// Concrete release tasks that should be completed.
+    /// </summary>
+    [Description("Concrete release tasks that should be completed.")]
+    public required IReadOnlyList<string> Tasks { get; init; }
+}
+
+/// <summary>
+/// Local Semantic Kernel plugin that exposes release facts to GigaChat through function calling.
+/// </summary>
+internal sealed class ReleasePlugin(string model)
+{
+    /// <summary>
+    /// Returns the package version that the example should mention in release answers.
+    /// </summary>
+    [KernelFunction("get_package_version")]
+    [Description("Returns the current package version for the Semantic Kernel adapter.")]
+    public string GetPackageVersion(
+        [Description("NuGet package id to inspect.")] string packageId = "GigaChat.Net.SemanticKernel")
+    {
+        return packageId.Equals("GigaChat.Net.SemanticKernel", StringComparison.OrdinalIgnoreCase)
+            ? "0.1.0-preview.semantic-kernel"
+            : "unknown";
+    }
+
+    /// <summary>
+    /// Returns a synthetic local CI status for the example release flow.
+    /// </summary>
+    [KernelFunction("get_ci_status")]
+    [Description("Returns the latest local CI status for a release branch.")]
+    public string GetCiStatus(
+        [Description("Branch name to inspect.")] string branch = "semantic-kernel")
+    {
+        return JsonSerializer.Serialize(
+            new
+            {
+                branch,
+                model,
+                build = "expected: dotnet build",
+                tests = "expected: dotnet test",
+                package = "expected: dotnet pack"
+            },
+            new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+            });
+    }
+}

--- a/examples/GigaChat.SemanticKernel.Example/README.md
+++ b/examples/GigaChat.SemanticKernel.Example/README.md
@@ -1,0 +1,40 @@
+# GigaChat.SemanticKernel.Example
+
+This example shows several ways to use `GigaChat.Net.SemanticKernel`:
+
+- `IChatCompletionService` with `ChatHistory` and `GigaChatPromptExecutionSettings`;
+- streaming through Semantic Kernel;
+- Semantic Kernel plugins/tools through `FunctionChoiceBehavior.Auto()`;
+- `ChatCompletionAgent` with the same GigaChat-backed tools;
+- structured output with Semantic Kernel `response_format`;
+- direct `GigaChat.Net` SDK calls for models, token count, and embeddings.
+
+## Configuration
+
+Set one authentication variable:
+
+```bash
+export GIGACHAT_CREDENTIALS="<authorization-key>"
+# or
+export GIGACHAT_ACCESS_TOKEN="<access-token>"
+```
+
+Optional variables:
+
+```bash
+export GIGACHAT_MODEL="GigaChat"
+export GIGACHAT_SCOPE="GIGACHAT_API_PERS"
+export GIGACHAT_CA_BUNDLE_FILE="/path/to/russian_trusted_root_ca.cer"
+export GIGACHAT_MAX_RETRIES="3"
+export GIGACHAT_RETRY_BACKOFF_FACTOR="0.5"
+export GIGACHAT_REASONING_EFFORT="low"
+export GIGACHAT_CLIENT_ID="client-id"
+export GIGACHAT_SESSION_ID="session-id"
+export GIGACHAT_TRACE_ID="trace-id"
+```
+
+## Run
+
+```bash
+dotnet run --project examples/GigaChat.SemanticKernel.Example/GigaChat.SemanticKernel.Example.csproj -- "Составь чеклист релиза SDK"
+```

--- a/src/GigaChat.Net.SemanticKernel/GigaChat.Net.SemanticKernel.csproj
+++ b/src/GigaChat.Net.SemanticKernel/GigaChat.Net.SemanticKernel.csproj
@@ -6,35 +6,38 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <!-- NuGet Package Metadata -->
-    <PackageId>GigaChat.Net.AspNetCore</PackageId>
+    <PackageId>GigaChat.Net.SemanticKernel</PackageId>
     <Version>1.1.0</Version>
     <Authors>GigaChat.Net Contributors</Authors>
-    <Description>ASP.NET Core dependency injection and request context extensions for GigaChat.Net.</Description>
-    <PackageTags>gigachat;aspnetcore;dependency-injection;ai;llm;sber;extensions</PackageTags>
+    <Description>Semantic Kernel connector for GigaChat.Net — IChatCompletionService, streaming, function calling, ReAct agent builder, and step tracing.</Description>
+    <PackageTags>gigachat;semantic-kernel;ai;llm;sber;agents;react;chat;completions;tool-calling</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/h0tnanny/GigaChat-Net</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/h0tnanny/GigaChat-Net</PackageProjectUrl>
-    <PackageReleaseNotes>Add explicit package targets for every .NET version from .NET 6 through .NET 10.</PackageReleaseNotes>
+    <PackageReleaseNotes>First stable release. Adds GigaChatReActAgent fluent builder, per-step tracing (GigaChatAgentStep), tool safety guardrails, instruction templates, and multi-turn thread persistence. Supports net6–net10.</PackageReleaseNotes>
 
-    <!-- Symbol and Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
-    <!-- Documentation -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.76.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\GigaChat.Net\GigaChat.Net.csproj" />
-    <None Include="..\..\docs\nuget\GigaChat.Net.AspNetCore.md" Pack="true" PackagePath="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\docs\nuget\GigaChat.Net.SemanticKernel.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>

--- a/src/GigaChat.Net.SemanticKernel/GigaChatAgentRunResult.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatAgentRunResult.cs
@@ -1,0 +1,20 @@
+using Microsoft.SemanticKernel;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>The result of a full GigaChat ReAct agent run.</summary>
+public sealed class GigaChatAgentRunResult
+{
+    /// <summary>Final assistant reply messages only.</summary>
+    public IReadOnlyList<ChatMessageContent> Messages { get; init; } = [];
+
+    /// <summary>
+    /// All messages generated during this run in order: intermediate assistant function-call
+    /// messages, tool-result messages, and the final reply. Use this when persisting thread
+    /// history so that future turns see the complete tool-use context.
+    /// </summary>
+    public IReadOnlyList<ChatMessageContent> FullRunMessages { get; init; } = [];
+
+    /// <summary>Ordered list of steps executed during the run.</summary>
+    public IReadOnlyList<GigaChatAgentStep> Steps { get; init; } = [];
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatAgentStep.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatAgentStep.cs
@@ -1,0 +1,41 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Base class for a single ReAct agent step.</summary>
+public abstract class GigaChatAgentStep
+{
+    /// <summary>Zero-based index of the LLM request this step belongs to.</summary>
+    public int RequestIndex { get; init; }
+
+    /// <summary>Name of the tool involved, or null for assistant message steps.</summary>
+    public string? ToolName { get; init; }
+
+    /// <summary>Wall-clock duration of this step in milliseconds.</summary>
+    public long LatencyMs { get; init; }
+}
+
+/// <summary>A tool call issued by the model.</summary>
+public sealed class GigaChatToolCallStep : GigaChatAgentStep
+{
+    /// <summary>The raw function call arguments dictionary.</summary>
+    public IReadOnlyDictionary<string, object?>? Arguments { get; init; }
+}
+
+/// <summary>The result returned after invoking a tool.</summary>
+public sealed class GigaChatToolResultStep : GigaChatAgentStep
+{
+    /// <summary>The serialized tool result sent back to the model.</summary>
+    public string Result { get; init; } = string.Empty;
+
+    /// <summary>The exception thrown during tool execution, if any.</summary>
+    public Exception? Exception { get; init; }
+}
+
+/// <summary>The final assistant message produced by the model.</summary>
+public sealed class GigaChatAssistantMessageStep : GigaChatAgentStep
+{
+    /// <summary>The assistant's final text content.</summary>
+    public string Content { get; init; } = string.Empty;
+
+    /// <summary>Token usage for the final completion.</summary>
+    public object? Usage { get; init; }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatAgentThread.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatAgentThread.cs
@@ -1,0 +1,16 @@
+using Microsoft.SemanticKernel;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>A resumable agent conversation thread.</summary>
+public sealed class GigaChatAgentThread
+{
+    /// <summary>Stable identifier for this thread.</summary>
+    public string ThreadId { get; init; } = string.Empty;
+
+    /// <summary>Full message history for the thread.</summary>
+    public IReadOnlyList<ChatMessageContent> History { get; init; } = [];
+
+    /// <summary>All steps emitted across all runs in this thread.</summary>
+    public IReadOnlyList<GigaChatAgentStep> Steps { get; init; } = [];
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatChatCompletionService.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatChatCompletionService.cs
@@ -1,0 +1,559 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using GigaChat.Net.Models;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Services;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// Semantic Kernel chat completion service backed by <see cref="IGigaChatClient"/>.
+/// </summary>
+public sealed class GigaChatChatCompletionService : IChatCompletionService
+{
+    private const string DefaultModel = "GigaChat";
+
+    private readonly IGigaChatClient _client;
+    private readonly string _modelId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GigaChatChatCompletionService"/> class.
+    /// </summary>
+    public GigaChatChatCompletionService(
+        IGigaChatClient client,
+        string? modelId = null,
+        string? endpoint = null)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        _client = client;
+        _modelId = string.IsNullOrWhiteSpace(modelId) ? DefaultModel : modelId;
+
+        var attributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            [AIServiceExtensions.ModelIdKey] = _modelId
+        };
+
+        if (!string.IsNullOrWhiteSpace(endpoint))
+            attributes[AIServiceExtensions.EndpointKey] = endpoint;
+
+        Attributes = attributes;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, object?> Attributes { get; }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsAsync(
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings = null,
+        Kernel? kernel = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(chatHistory);
+
+        var settings = GigaChatPromptExecutionSettings.FromExecutionSettings(executionSettings);
+        var functionMap = GigaChatKernelFunctionMapper.CreateFunctionMap(chatHistory, settings, kernel);
+        if (ShouldAutoInvokeFunctions(functionMap))
+            return await GetChatMessageContentsWithToolsAsync(chatHistory, settings, kernel, cancellationToken);
+
+        var chat = CreateChat(chatHistory, settings, functionMap);
+        var completion = await _client.ChatAsync(chat, settings.Headers, cancellationToken);
+
+        return completion.Choices
+            .Select(choice => CreateChatMessageContent(choice, completion, functionMap: functionMap))
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<StreamingChatMessageContent> GetStreamingChatMessageContentsAsync(
+        ChatHistory chatHistory,
+        PromptExecutionSettings? executionSettings = null,
+        Kernel? kernel = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(chatHistory);
+
+        var settings = GigaChatPromptExecutionSettings.FromExecutionSettings(executionSettings);
+        var functionMap = GigaChatKernelFunctionMapper.CreateFunctionMap(chatHistory, settings, kernel);
+        if (ShouldAutoInvokeFunctions(functionMap))
+        {
+            var messages = await GetChatMessageContentsWithToolsAsync(
+                chatHistory,
+                settings,
+                kernel,
+                cancellationToken);
+
+            foreach (var message in messages)
+            {
+                yield return new StreamingChatMessageContent(
+                    message.Role,
+                    message.Content,
+                    innerContent: message.InnerContent,
+                    modelId: message.ModelId,
+                    metadata: message.Metadata);
+            }
+
+            yield break;
+        }
+
+        var chat = CreateChat(chatHistory, settings, functionMap);
+
+        await foreach (var chunk in _client.StreamAsync(chat, settings.Headers, cancellationToken))
+        {
+            foreach (var choice in chunk.Choices)
+            {
+                AuthorRole? role = choice.Delta.Role is null
+                    ? null
+                    : ToAuthorRole(choice.Delta.Role.Value);
+                var metadata = CreateStreamingMetadata(choice, chunk);
+                yield return new StreamingChatMessageContent(
+                    role,
+                    choice.Delta.Content,
+                    innerContent: chunk,
+                    choiceIndex: choice.Index,
+                    modelId: chunk.Model,
+                    metadata: metadata);
+            }
+        }
+    }
+
+    private Chat CreateChat(
+        ChatHistory chatHistory,
+        GigaChatPromptExecutionSettings settings,
+        GigaChatKernelFunctionMap? functionMap = null)
+    {
+        return CreateChat(chatHistory.Select(ToGigaChatMessage).ToArray(), settings, functionMap);
+    }
+
+    private Chat CreateChat(
+        IReadOnlyList<Messages> messages,
+        GigaChatPromptExecutionSettings settings,
+        GigaChatKernelFunctionMap? functionMap = null)
+    {
+        return new Chat
+        {
+            Model = settings.ModelId ?? _modelId,
+            Messages = messages,
+            Temperature = settings.Temperature,
+            TopP = settings.TopP,
+            MaxTokens = settings.MaxTokens,
+            RepetitionPenalty = settings.RepetitionPenalty,
+            ProfanityCheck = settings.ProfanityCheck,
+            Flags = settings.Flags,
+            ReasoningEffort = settings.ReasoningEffort,
+            FunctionCall = ToGigaChatFunctionCallMode(functionMap),
+            Functions = functionMap is { Choice: var c } && c != FunctionChoice.None ? functionMap.Functions : null,
+            AdditionalFields = settings.AdditionalFields
+        };
+    }
+
+    /// <summary>
+    /// Executes a chat completion with tool auto-invocation and returns the result with a per-step trace.
+    /// </summary>
+    public async Task<GigaChatAgentRunResult> RunWithStepsAsync(
+        IReadOnlyList<ChatMessageContent> history,
+        GigaChatPromptExecutionSettings? executionSettings = null,
+        Kernel? kernel = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+        var chatHistory = new ChatHistory();
+        foreach (var msg in history)
+            chatHistory.Add(msg);
+
+        var settings = GigaChatPromptExecutionSettings.FromExecutionSettings(executionSettings);
+        var steps = new List<GigaChatAgentStep>();
+        var allGenerated = new List<ChatMessageContent>();
+        var finalMessages = await RunToolLoopAsync(chatHistory, settings, kernel, steps, allGenerated, cancellationToken);
+        return new GigaChatAgentRunResult
+        {
+            Messages = finalMessages,
+            FullRunMessages = allGenerated,
+            Steps = steps
+        };
+    }
+
+    private Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsWithToolsAsync(
+        ChatHistory chatHistory,
+        GigaChatPromptExecutionSettings settings,
+        Kernel? kernel,
+        CancellationToken cancellationToken)
+    {
+        return RunToolLoopAsync(chatHistory, settings, kernel, steps: null, allGenerated: null, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<ChatMessageContent>> RunToolLoopAsync(
+        ChatHistory chatHistory,
+        GigaChatPromptExecutionSettings settings,
+        Kernel? kernel,
+        List<GigaChatAgentStep>? steps,
+        List<ChatMessageContent>? allGenerated,
+        CancellationToken cancellationToken)
+    {
+        if (kernel is null)
+            throw new InvalidOperationException("Semantic Kernel function calling requires a Kernel instance.");
+
+        var messages = chatHistory.Select(ToGigaChatMessage).ToList();
+        var functionCalls = new List<ExecutedFunctionCall>();
+
+        for (var requestIndex = 0; ; requestIndex++)
+        {
+            var functionMap = GigaChatKernelFunctionMapper.CreateFunctionMap(
+                chatHistory,
+                settings,
+                kernel,
+                requestIndex);
+            var chat = CreateChat(messages, settings, functionMap);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var completion = await _client.ChatAsync(chat, settings.Headers, cancellationToken);
+            sw.Stop();
+            if (completion.Choices.Count == 0)
+                throw new GigaChatException("GigaChat returned a completion with no choices.");
+            var choice = completion.Choices[0];
+            var message = choice.Message;
+
+            if (!IsFunctionCall(choice))
+            {
+                messages.Add(message);
+                steps?.Add(new GigaChatAssistantMessageStep
+                {
+                    RequestIndex = requestIndex,
+                    LatencyMs = sw.ElapsedMilliseconds,
+                    Content = message.Content ?? string.Empty,
+                    Usage = completion.Usage
+                });
+                var finalMessages = completion.Choices
+                    .Select(finalChoice => CreateChatMessageContent(finalChoice, completion, functionCalls, functionMap))
+                    .ToArray();
+                allGenerated?.AddRange(finalMessages);
+                return finalMessages;
+            }
+
+            messages.Add(message);
+
+            if (functionCalls.Count + 1 > settings.MaxToolCalls)
+                throw new GigaChatException($"Semantic Kernel function calling exceeded the maximum of {settings.MaxToolCalls} tool calls.");
+
+            var functionCall = message.FunctionCall
+                ?? throw new GigaChatException("Model returned function_call finish reason without function_call payload.");
+
+            if (functionMap is null || !functionMap.FunctionsByGigaChatName.TryGetValue(functionCall.Name, out var kernelFunction))
+                throw new GigaChatException($"Unknown Semantic Kernel function call '{functionCall.Name}'.");
+
+            // Capture the intermediate assistant function-call message so thread history stays complete.
+            allGenerated?.Add(CreateChatMessageContent(choice, completion, null, functionMap));
+
+            steps?.Add(new GigaChatToolCallStep
+            {
+                RequestIndex = requestIndex,
+                ToolName = functionCall.Name,
+                LatencyMs = sw.ElapsedMilliseconds,
+                Arguments = functionCall.Arguments
+            });
+
+            var safety = settings.ToolSafety;
+
+            if (safety?.AllowedPlugins is not null
+                && (kernelFunction.Metadata.PluginName is null
+                    || !safety.AllowedPlugins.Contains(kernelFunction.Metadata.PluginName)))
+            {
+                throw new GigaChatException(
+                    $"Plugin '{kernelFunction.Metadata.PluginName}' is not in the allowed-plugins list.");
+            }
+
+            var toolSw = System.Diagnostics.Stopwatch.StartNew();
+            string result;
+            Exception? toolEx = null;
+            try
+            {
+                result = await InvokeKernelFunctionAsync(kernel, kernelFunction, functionCall, cancellationToken);
+            }
+            catch (Exception ex) when (safety?.ErrorBehavior == GigaChatToolErrorBehavior.ReturnObservation)
+            {
+                toolEx = ex;
+                result = $"Tool error ({ex.GetType().Name}): {ex.Message}";
+            }
+            toolSw.Stop();
+
+            if (safety?.MaxOutputLength is int maxLen && result.Length > maxLen)
+                result = result[..maxLen] + "[truncated]";
+
+            steps?.Add(new GigaChatToolResultStep
+            {
+                RequestIndex = requestIndex,
+                ToolName = functionCall.Name,
+                LatencyMs = toolSw.ElapsedMilliseconds,
+                Result = result,
+                Exception = toolEx
+            });
+
+            // Capture the tool-result message so thread history stays complete.
+            allGenerated?.Add(new ChatMessageContent(AuthorRole.Tool, result));
+
+            messages.Add(Messages.Function(functionCall.Name, result));
+            functionCalls.Add(new ExecutedFunctionCall(functionCall, result));
+        }
+    }
+
+    private static object? ToGigaChatFunctionCallMode(GigaChatKernelFunctionMap? functionMap)
+    {
+        if (functionMap is null)
+            return null;
+        if (functionMap.Choice == FunctionChoice.None)
+            return null;
+        if (functionMap.Choice == FunctionChoice.Required && functionMap.Functions.Count == 1)
+            return ChatFunctionCall.For(functionMap.Functions[0].Name);
+
+        return FunctionCallMode.Auto;
+    }
+
+    private static bool ShouldAutoInvokeFunctions(GigaChatKernelFunctionMap? functionMap)
+    {
+        return functionMap is { AutoInvoke: true } && functionMap.Choice != FunctionChoice.None;
+    }
+
+    private static bool IsFunctionCall(Choices choice)
+    {
+        return string.Equals(choice.FinishReason, "function_call", StringComparison.OrdinalIgnoreCase)
+            || choice.Message.FunctionCall is not null;
+    }
+
+    private static async Task<string> InvokeKernelFunctionAsync(
+        Kernel kernel,
+        KernelFunction function,
+        FunctionCall functionCall,
+        CancellationToken cancellationToken)
+    {
+        var arguments = ToKernelArguments(functionCall.Arguments);
+        var result = await function.InvokeAsync(kernel, arguments, cancellationToken);
+        return FormatFunctionResult(result.GetValue<object?>());
+    }
+
+    private static KernelArguments ToKernelArguments(Dictionary<string, object?>? arguments)
+    {
+        var kernelArguments = new KernelArguments();
+        if (arguments is null)
+            return kernelArguments;
+
+        foreach (var argument in arguments)
+            kernelArguments[argument.Key] = UnwrapJsonElement(argument.Value);
+
+        return kernelArguments;
+    }
+
+    private static string FormatFunctionResult(object? value)
+    {
+        return value switch
+        {
+            null => string.Empty,
+            string text => text,
+            JsonElement element => element.GetRawText(),
+            _ when value.GetType().IsPrimitive => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+            decimal number => number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            DateTime dateTime => dateTime.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset dateTime => dateTime.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            _ => JsonSerializer.Serialize(value, new JsonSerializerOptions(JsonSerializerDefaults.Web))
+        };
+    }
+
+    private static object? UnwrapJsonElement(object? value)
+    {
+        return value is JsonElement element
+            ? JsonSerializer.Deserialize<object?>(element.GetRawText())
+            : value;
+    }
+
+    private static Messages ToGigaChatMessage(ChatMessageContent message)
+    {
+        ValidateSupportedItems(message);
+
+        var functionCall = message.Items.OfType<FunctionCallContent>().FirstOrDefault();
+        if (functionCall is not null)
+        {
+            if (string.IsNullOrWhiteSpace(functionCall.FunctionName))
+                throw new NotSupportedException("Semantic Kernel function call content must include a function name.");
+
+            return Messages.Assistant(
+                GetTextContent(message),
+                new FunctionCall
+                {
+                    Name = GigaChatKernelFunctionMapper.ToGigaChatFunctionName(
+                        functionCall.PluginName,
+                        functionCall.FunctionName),
+                    Arguments = ToGigaChatArguments(functionCall.Arguments)
+                });
+        }
+
+        var functionResult = message.Items.OfType<FunctionResultContent>().FirstOrDefault();
+        if (functionResult is not null)
+        {
+            if (string.IsNullOrWhiteSpace(functionResult.FunctionName))
+                throw new NotSupportedException("Semantic Kernel function result content must include a function name.");
+
+            return Messages.Function(
+                GigaChatKernelFunctionMapper.ToGigaChatFunctionName(
+                    functionResult.PluginName,
+                    functionResult.FunctionName),
+                FormatFunctionResult(functionResult.Result));
+        }
+
+        var role = ToGigaChatRole(message.Role);
+        return role == MessagesRole.Function
+            ? Messages.Function(message.AuthorName ?? "tool", GetTextContent(message))
+            : new Messages
+            {
+                Role = role,
+                Content = GetTextContent(message)
+            };
+    }
+
+    private static void ValidateSupportedItems(ChatMessageContent message)
+    {
+        foreach (var item in message.Items)
+        {
+            if (item is TextContent or FunctionCallContent or FunctionResultContent)
+                continue;
+
+            throw new NotSupportedException(
+                $"GigaChat Semantic Kernel connector supports text and function content items only. Unsupported item: {item.GetType().Name}.");
+        }
+    }
+
+    private static string GetTextContent(ChatMessageContent message)
+    {
+        var text = string.Concat(message.Items.OfType<TextContent>().Select(item => item.Text));
+        return string.IsNullOrEmpty(text) ? message.Content ?? string.Empty : text;
+    }
+
+    private static Dictionary<string, object?>? ToGigaChatArguments(KernelArguments? arguments)
+    {
+        if (arguments is null || arguments.Count == 0)
+            return null;
+
+        var result = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var argument in arguments)
+            result[argument.Key] = argument.Value;
+
+        return result;
+    }
+
+    private static MessagesRole ToGigaChatRole(AuthorRole role)
+    {
+        if (role == AuthorRole.Assistant)
+            return MessagesRole.Assistant;
+        if (role == AuthorRole.System)
+            return MessagesRole.System;
+        if (role == AuthorRole.Tool)
+            return MessagesRole.Function;
+
+        return MessagesRole.User;
+    }
+
+    private static AuthorRole ToAuthorRole(MessagesRole role)
+    {
+        return role switch
+        {
+            MessagesRole.Assistant => AuthorRole.Assistant,
+            MessagesRole.System => AuthorRole.System,
+            MessagesRole.Function => AuthorRole.Tool,
+            _ => AuthorRole.User
+        };
+    }
+
+    private static ChatMessageContent CreateChatMessageContent(
+        Choices choice,
+        ChatCompletion completion,
+        IReadOnlyList<ExecutedFunctionCall>? functionCalls = null,
+        GigaChatKernelFunctionMap? functionMap = null)
+    {
+        var metadata = CreateMessageMetadata(choice, completion, functionCalls);
+        var content = new ChatMessageContent(
+            ToAuthorRole(choice.Message.Role),
+            choice.Message.Content,
+            modelId: completion.Model,
+            innerContent: completion,
+            metadata: metadata)
+        {
+            AuthorName = choice.Message.Name
+        };
+
+        if (choice.Message.FunctionCall is not null)
+            content.Items.Add(ToFunctionCallContent(choice.Message.FunctionCall, functionMap));
+
+        return content;
+    }
+
+    private static FunctionCallContent ToFunctionCallContent(
+        FunctionCall functionCall,
+        GigaChatKernelFunctionMap? functionMap)
+    {
+        if (functionMap is not null
+            && functionMap.FunctionsByGigaChatName.TryGetValue(functionCall.Name, out var kernelFunction))
+        {
+            return new FunctionCallContent(
+                kernelFunction.Metadata.Name,
+                kernelFunction.Metadata.PluginName,
+                functionCall.Name,
+                ToKernelArguments(functionCall.Arguments));
+        }
+
+        var (pluginName, functionName) = SplitGigaChatFunctionName(functionCall.Name);
+        return new FunctionCallContent(
+            functionName,
+            pluginName,
+            functionCall.Name,
+            ToKernelArguments(functionCall.Arguments));
+    }
+
+    private static (string? PluginName, string FunctionName) SplitGigaChatFunctionName(string name)
+    {
+        var separatorIndex = name.LastIndexOf('_');
+        return separatorIndex <= 0 || separatorIndex == name.Length - 1
+            ? (null, name)
+            : (name[..separatorIndex], name[(separatorIndex + 1)..]);
+    }
+
+    private static IReadOnlyDictionary<string, object?> CreateMessageMetadata(
+        Choices choice,
+        ChatCompletion completion,
+        IReadOnlyList<ExecutedFunctionCall>? functionCalls = null)
+    {
+        var metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["finish_reason"] = choice.FinishReason,
+            ["created"] = completion.Created,
+            ["usage"] = completion.Usage
+        };
+
+        if (!string.IsNullOrWhiteSpace(completion.ThreadId))
+            metadata["thread_id"] = completion.ThreadId;
+        if (!string.IsNullOrWhiteSpace(completion.MessageId))
+            metadata["message_id"] = completion.MessageId;
+        if (completion.XHeaders is not null)
+            metadata["x_headers"] = completion.XHeaders;
+        if (functionCalls is { Count: > 0 })
+            metadata["function_calls"] = functionCalls;
+
+        return metadata;
+    }
+
+    private static IReadOnlyDictionary<string, object?> CreateStreamingMetadata(
+        ChoicesChunk choice,
+        ChatCompletionChunk chunk)
+    {
+        var metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["finish_reason"] = choice.FinishReason,
+            ["created"] = chunk.Created
+        };
+
+        if (chunk.Usage is not null)
+            metadata["usage"] = chunk.Usage;
+        if (chunk.XHeaders is not null)
+            metadata["x_headers"] = chunk.XHeaders;
+
+        return metadata;
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatKernelBuilderExtensions.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatKernelBuilderExtensions.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// Semantic Kernel registration helpers for GigaChat.
+/// </summary>
+public static class GigaChatKernelBuilderExtensions
+{
+    /// <summary>
+    /// Adds a GigaChat-backed chat completion service to a Semantic Kernel builder.
+    /// </summary>
+    public static IKernelBuilder AddGigaChatChatCompletion(
+        this IKernelBuilder builder,
+        Settings? settings = null,
+        string? serviceId = null,
+        string? modelId = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.TryAddSingleton<IGigaChatClient>(_ => new GigaChatClient(settings));
+        builder.Services.AddGigaChatChatCompletionService(serviceId, modelId, settings?.BaseUrl);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a GigaChat-backed chat completion service using an existing client instance.
+    /// </summary>
+    public static IKernelBuilder AddGigaChatChatCompletion(
+        this IKernelBuilder builder,
+        IGigaChatClient client,
+        string? serviceId = null,
+        string? modelId = null,
+        string? endpoint = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(client);
+
+        builder.Services.TryAddSingleton(client);
+        builder.Services.AddGigaChatChatCompletionService(serviceId, modelId, endpoint);
+        return builder;
+    }
+
+    private static void AddGigaChatChatCompletionService(
+        this IServiceCollection services,
+        string? serviceId,
+        string? modelId,
+        string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(serviceId))
+        {
+            services.AddSingleton<IChatCompletionService>(provider =>
+                new GigaChatChatCompletionService(
+                    provider.GetRequiredService<IGigaChatClient>(),
+                    modelId,
+                    endpoint));
+            return;
+        }
+
+        services.AddKeyedSingleton<IChatCompletionService>(serviceId, (provider, _) =>
+            new GigaChatChatCompletionService(
+                provider.GetRequiredService<IGigaChatClient>(),
+                modelId,
+                endpoint));
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatKernelFunctionMapper.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatKernelFunctionMapper.cs
@@ -1,0 +1,305 @@
+using System.Text.Json;
+using GigaChat.Net.Models;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.SemanticKernel;
+
+internal sealed record GigaChatKernelFunctionMap(
+    IReadOnlyList<Function> Functions,
+    IReadOnlyDictionary<string, KernelFunction> FunctionsByGigaChatName,
+    FunctionChoice Choice,
+    bool AutoInvoke);
+
+internal static class GigaChatKernelFunctionMapper
+{
+    private const char FunctionNameSeparator = '_';
+
+    public static GigaChatKernelFunctionMap? CreateFunctionMap(
+        ChatHistory chatHistory,
+        GigaChatPromptExecutionSettings settings,
+        Kernel? kernel,
+        int requestSequenceIndex = 0)
+    {
+        if (settings.FunctionChoiceBehavior is null)
+            return null;
+
+        var context = new FunctionChoiceBehaviorConfigurationContext(chatHistory)
+        {
+            Kernel = kernel,
+            RequestSequenceIndex = requestSequenceIndex
+        };
+        var configuration = settings.FunctionChoiceBehavior.GetConfiguration(context);
+        if (configuration is null)
+            return null;
+
+        var kernelFunctions = configuration.Functions;
+        if (kernelFunctions is null || kernelFunctions.Count == 0)
+            return null;
+
+        var functions = new List<Function>(kernelFunctions.Count);
+        var functionsByName = new Dictionary<string, KernelFunction>(StringComparer.Ordinal);
+        foreach (var kernelFunction in kernelFunctions)
+        {
+            var metadata = kernelFunction.Metadata;
+            var name = ToGigaChatFunctionName(metadata);
+            if (!functionsByName.TryAdd(name, kernelFunction))
+                throw new InvalidOperationException($"Duplicate Semantic Kernel function name '{name}'.");
+
+            functions.Add(new Function
+            {
+                Name = name,
+                Description = metadata.Description,
+                Parameters = ToFunctionParameters(metadata)
+            });
+        }
+
+        return new GigaChatKernelFunctionMap(
+            functions,
+            functionsByName,
+            configuration.Choice,
+            configuration.AutoInvoke);
+    }
+
+    public static string ToGigaChatFunctionName(string? pluginName, string functionName)
+    {
+        ThrowIfNullOrWhiteSpace(functionName, nameof(functionName));
+
+        return string.IsNullOrWhiteSpace(pluginName)
+            ? functionName
+            : $"{pluginName}{FunctionNameSeparator}{functionName}";
+    }
+
+    public static string ToGigaChatFunctionName(KernelFunctionMetadata metadata)
+    {
+        return ToGigaChatFunctionName(metadata.PluginName, metadata.Name);
+    }
+
+    private static FunctionParameters ToFunctionParameters(KernelFunctionMetadata metadata)
+    {
+        var properties = new Dictionary<string, FunctionParametersProperty>(StringComparer.Ordinal);
+        var required = new List<string>();
+
+        foreach (var parameter in metadata.Parameters)
+        {
+            properties[parameter.Name] = ToFunctionParameterProperty(parameter);
+            if (parameter.IsRequired)
+                required.Add(parameter.Name);
+        }
+
+        return new FunctionParameters
+        {
+            Type = "object",
+            Properties = properties,
+            Required = required.Count == 0 ? null : required
+        };
+    }
+
+    private static FunctionParametersProperty ToFunctionParameterProperty(KernelParameterMetadata parameter)
+    {
+        var schema = parameter.Schema?.RootElement;
+        if (schema is not null && schema.Value.ValueKind == JsonValueKind.Object)
+            return ToFunctionParameterProperty(schema.Value, parameter.Description);
+
+        return InferFunctionParameterProperty(parameter.ParameterType, parameter.Description);
+    }
+
+    private static FunctionParametersProperty ToFunctionParameterProperty(
+        JsonElement schema,
+        string? fallbackDescription)
+    {
+        var type = TryGetString(schema, "type") ?? "object";
+        if (string.Equals(type, "null", StringComparison.OrdinalIgnoreCase))
+            type = "object";
+
+        var property = new FunctionParametersProperty
+        {
+            Type = type,
+            Description = TryGetString(schema, "description") ?? fallbackDescription ?? string.Empty,
+            Enum = ReadStringArray(schema, "enum")
+        };
+
+        if (schema.TryGetProperty("items", out var items) && items.ValueKind == JsonValueKind.Object)
+            property = property with { Items = ToDictionary(ToFunctionParameterProperty(items, null)) };
+
+        if (schema.TryGetProperty("properties", out var propertiesElement)
+            && propertiesElement.ValueKind == JsonValueKind.Object)
+        {
+            var properties = new Dictionary<string, FunctionParametersProperty>(StringComparer.Ordinal);
+            foreach (var item in propertiesElement.EnumerateObject())
+            {
+                if (item.Value.ValueKind == JsonValueKind.Object)
+                    properties[item.Name] = ToFunctionParameterProperty(item.Value, null);
+            }
+
+            property = property with { Properties = properties };
+        }
+
+        var additionalFields = ReadAdditionalFields(schema);
+        return additionalFields.Count == 0
+            ? property
+            : property with { AdditionalFields = additionalFields };
+    }
+
+    private static FunctionParametersProperty InferFunctionParameterProperty(
+        Type? type,
+        string? description)
+    {
+        if (type is null)
+            return new FunctionParametersProperty { Type = "object", Description = description ?? string.Empty };
+
+        var nullableType = Nullable.GetUnderlyingType(type);
+        type = nullableType ?? type;
+
+        if (type == typeof(string) || type == typeof(Guid) || type == typeof(DateTime) || type == typeof(DateTimeOffset))
+            return new FunctionParametersProperty { Type = "string", Description = description ?? string.Empty };
+
+        if (type == typeof(bool))
+            return new FunctionParametersProperty { Type = "boolean", Description = description ?? string.Empty };
+
+        if (IsInteger(type))
+            return new FunctionParametersProperty { Type = "integer", Description = description ?? string.Empty };
+
+        if (IsNumber(type))
+            return new FunctionParametersProperty { Type = "number", Description = description ?? string.Empty };
+
+        if (type.IsEnum)
+        {
+            return new FunctionParametersProperty
+            {
+                Type = "string",
+                Description = description ?? string.Empty,
+                Enum = Enum.GetNames(type)
+            };
+        }
+
+        if (TryGetEnumerableElementType(type, out var elementType))
+        {
+            return new FunctionParametersProperty
+            {
+                Type = "array",
+                Description = description ?? string.Empty,
+                Items = ToDictionary(InferFunctionParameterProperty(elementType, null))
+            };
+        }
+
+        return new FunctionParametersProperty { Type = "object", Description = description ?? string.Empty };
+    }
+
+    private static Dictionary<string, object?> ToDictionary(FunctionParametersProperty property)
+    {
+        var dictionary = new Dictionary<string, object?>
+        {
+            ["type"] = property.Type
+        };
+
+        if (!string.IsNullOrEmpty(property.Description))
+            dictionary["description"] = property.Description;
+        if (property.Items is not null)
+            dictionary["items"] = property.Items;
+        if (property.Enum is not null)
+            dictionary["enum"] = property.Enum;
+        if (property.Properties is not null)
+        {
+            dictionary["properties"] = property.Properties.ToDictionary(
+                item => item.Key,
+                item => (object?)ToDictionary(item.Value));
+        }
+        if (property.AdditionalFields is not null)
+        {
+            foreach (var item in property.AdditionalFields)
+                dictionary[item.Key] = item.Value;
+        }
+
+        return dictionary;
+    }
+
+    private static Dictionary<string, object?> ReadAdditionalFields(JsonElement schema)
+    {
+        var fields = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var item in schema.EnumerateObject())
+        {
+            if (item.Name is "type" or "description" or "items" or "enum" or "properties")
+                continue;
+
+            fields[item.Name] = JsonSerializer.Deserialize<object?>(item.Value.GetRawText());
+        }
+
+        return fields;
+    }
+
+    private static string? TryGetString(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
+    private static IReadOnlyList<string>? ReadStringArray(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.Array)
+            return null;
+
+        return property
+            .EnumerateArray()
+            .Where(item => item.ValueKind == JsonValueKind.String)
+            .Select(item => item.GetString())
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Select(item => item!)
+            .ToArray();
+    }
+
+    private static bool IsInteger(Type type)
+    {
+        return type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong);
+    }
+
+    private static bool IsNumber(Type type)
+    {
+        return type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal);
+    }
+
+    private static bool TryGetEnumerableElementType(Type type, out Type elementType)
+    {
+        if (type == typeof(string))
+        {
+            elementType = typeof(object);
+            return false;
+        }
+
+        if (type.IsArray)
+        {
+            elementType = type.GetElementType()!;
+            return true;
+        }
+
+        var enumerable = type
+            .GetInterfaces()
+            .Concat([type])
+            .FirstOrDefault(item => item.IsGenericType && item.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        if (enumerable is null)
+        {
+            elementType = typeof(object);
+            return false;
+        }
+
+        elementType = enumerable.GetGenericArguments()[0];
+        return true;
+    }
+
+    private static void ThrowIfNullOrWhiteSpace(string? value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be null or whitespace.", paramName);
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatPromptExecutionSettings.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatPromptExecutionSettings.cs
@@ -1,0 +1,353 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.SemanticKernel;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// GigaChat-specific prompt execution settings for Semantic Kernel.
+/// </summary>
+public sealed class GigaChatPromptExecutionSettings : PromptExecutionSettings
+{
+    private double? _temperature;
+    private double? _topP;
+    private int? _maxTokens;
+    private double? _repetitionPenalty;
+    private bool? _profanityCheck;
+    private IReadOnlyList<string>? _flags;
+    private string? _reasoningEffort;
+    private IReadOnlyDictionary<string, object?>? _additionalFields;
+    private GigaChatRequestHeaders? _headers;
+    private int _maxToolCalls = 8;
+    private GigaChatToolSafetyOptions? _toolSafety;
+
+    /// <summary>
+    /// Gets or sets the sampling temperature.
+    /// </summary>
+    [JsonPropertyName("temperature")]
+    public double? Temperature
+    {
+        get => _temperature;
+        set
+        {
+            ThrowIfFrozen();
+            _temperature = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets nucleus sampling probability.
+    /// </summary>
+    [JsonPropertyName("top_p")]
+    public double? TopP
+    {
+        get => _topP;
+        set
+        {
+            ThrowIfFrozen();
+            _topP = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum completion token count.
+    /// </summary>
+    [JsonPropertyName("max_tokens")]
+    public int? MaxTokens
+    {
+        get => _maxTokens;
+        set
+        {
+            ThrowIfFrozen();
+            _maxTokens = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the repetition penalty.
+    /// </summary>
+    [JsonPropertyName("repetition_penalty")]
+    public double? RepetitionPenalty
+    {
+        get => _repetitionPenalty;
+        set
+        {
+            ThrowIfFrozen();
+            _repetitionPenalty = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether GigaChat profanity filtering is enabled.
+    /// </summary>
+    [JsonPropertyName("profanity_check")]
+    public bool? ProfanityCheck
+    {
+        get => _profanityCheck;
+        set
+        {
+            ThrowIfFrozen();
+            _profanityCheck = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets GigaChat feature flags.
+    /// </summary>
+    [JsonPropertyName("flags")]
+    public IReadOnlyList<string>? Flags
+    {
+        get => _flags;
+        set
+        {
+            ThrowIfFrozen();
+            _flags = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets model reasoning effort.
+    /// </summary>
+    [JsonPropertyName("reasoning_effort")]
+    public string? ReasoningEffort
+    {
+        get => _reasoningEffort;
+        set
+        {
+            ThrowIfFrozen();
+            _reasoningEffort = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets provider-specific fields that should be merged into the GigaChat payload.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyDictionary<string, object?>? AdditionalFields
+    {
+        get => _additionalFields;
+        set
+        {
+            ThrowIfFrozen();
+            _additionalFields = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets per-request GigaChat header overrides.
+    /// </summary>
+    [JsonIgnore]
+    public GigaChatRequestHeaders? Headers
+    {
+        get => _headers;
+        set
+        {
+            ThrowIfFrozen();
+            _headers = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the maximum number of Semantic Kernel tool calls per chat completion.
+    /// </summary>
+    [JsonIgnore]
+    public int MaxToolCalls
+    {
+        get => _maxToolCalls;
+        set
+        {
+            ThrowIfFrozen();
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value), "Maximum tool calls cannot be negative.");
+
+            _maxToolCalls = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets tool safety and error-handling options. Null means FailFast with no truncation.
+    /// </summary>
+    [JsonIgnore]
+    public GigaChatToolSafetyOptions? ToolSafety
+    {
+        get => _toolSafety;
+        set
+        {
+            ThrowIfFrozen();
+            _toolSafety = value;
+        }
+    }
+
+    /// <inheritdoc />
+    public override PromptExecutionSettings Clone()
+    {
+        return new GigaChatPromptExecutionSettings
+        {
+            ServiceId = ServiceId,
+            ModelId = ModelId,
+            FunctionChoiceBehavior = FunctionChoiceBehavior,
+            ExtensionData = ExtensionData is null
+                ? null
+                : new Dictionary<string, object>(ExtensionData, StringComparer.OrdinalIgnoreCase),
+            Temperature = Temperature,
+            TopP = TopP,
+            MaxTokens = MaxTokens,
+            RepetitionPenalty = RepetitionPenalty,
+            ProfanityCheck = ProfanityCheck,
+            Flags = Flags?.ToArray(),
+            ReasoningEffort = ReasoningEffort,
+            AdditionalFields = AdditionalFields is null
+                ? null
+                : new Dictionary<string, object?>(AdditionalFields, StringComparer.OrdinalIgnoreCase),
+            Headers = Headers,
+            MaxToolCalls = MaxToolCalls,
+            ToolSafety = ToolSafety
+        };
+    }
+
+    /// <summary>
+    /// Converts generic Semantic Kernel execution settings into GigaChat settings.
+    /// </summary>
+    public static GigaChatPromptExecutionSettings FromExecutionSettings(PromptExecutionSettings? settings)
+    {
+        if (settings is null)
+            return new GigaChatPromptExecutionSettings();
+
+        if (settings is GigaChatPromptExecutionSettings gigaChatSettings)
+            return (GigaChatPromptExecutionSettings)gigaChatSettings.Clone();
+
+        var converted = new GigaChatPromptExecutionSettings
+        {
+            ServiceId = settings.ServiceId,
+            ModelId = settings.ModelId,
+            FunctionChoiceBehavior = settings.FunctionChoiceBehavior,
+            ExtensionData = settings.ExtensionData is null
+                ? null
+                : new Dictionary<string, object>(settings.ExtensionData, StringComparer.OrdinalIgnoreCase)
+        };
+
+        if (settings.ExtensionData is null)
+            return converted;
+
+        var additional = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in settings.ExtensionData)
+        {
+            switch (item.Key)
+            {
+                case "temperature":
+                    converted.Temperature = GetDouble(item.Value);
+                    break;
+                case "top_p":
+                    converted.TopP = GetDouble(item.Value);
+                    break;
+                case "max_tokens":
+                    converted.MaxTokens = GetInt(item.Value);
+                    break;
+                case "repetition_penalty":
+                    converted.RepetitionPenalty = GetDouble(item.Value);
+                    break;
+                case "profanity_check":
+                    converted.ProfanityCheck = GetBool(item.Value);
+                    break;
+                case "flags":
+                    converted.Flags = GetStringList(item.Value);
+                    break;
+                case "reasoning_effort":
+                    converted.ReasoningEffort = GetString(item.Value);
+                    break;
+                case "max_tool_calls":
+                    converted.MaxToolCalls = GetInt(item.Value) ?? converted.MaxToolCalls;
+                    break;
+                default:
+                    additional[item.Key] = UnwrapJsonElement(item.Value);
+                    break;
+            }
+        }
+
+        if (additional.Count > 0)
+            converted.AdditionalFields = additional;
+
+        return converted;
+    }
+
+    private static double? GetDouble(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            double number => number,
+            float number => number,
+            decimal number => (double)number,
+            int number => number,
+            long number => number,
+            JsonElement { ValueKind: JsonValueKind.Number } element when element.TryGetDouble(out var number) => number,
+            JsonElement { ValueKind: JsonValueKind.String } element when double.TryParse(element.GetString(), out var number) => number,
+            string text when double.TryParse(text, out var number) => number,
+            _ => null
+        };
+    }
+
+    private static int? GetInt(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            int number => number,
+            long number => checked((int)number),
+            JsonElement { ValueKind: JsonValueKind.Number } element when element.TryGetInt32(out var number) => number,
+            JsonElement { ValueKind: JsonValueKind.String } element when int.TryParse(element.GetString(), out var number) => number,
+            string text when int.TryParse(text, out var number) => number,
+            _ => null
+        };
+    }
+
+    private static bool? GetBool(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            bool flag => flag,
+            JsonElement { ValueKind: JsonValueKind.True } => true,
+            JsonElement { ValueKind: JsonValueKind.False } => false,
+            JsonElement { ValueKind: JsonValueKind.String } element when bool.TryParse(element.GetString(), out var flag) => flag,
+            string text when bool.TryParse(text, out var flag) => flag,
+            _ => null
+        };
+    }
+
+    private static string? GetString(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string text => text,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => value.ToString()
+        };
+    }
+
+    private static IReadOnlyList<string>? GetStringList(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            IReadOnlyList<string> list => list,
+            IEnumerable<string> list => list.ToArray(),
+            JsonElement { ValueKind: JsonValueKind.Array } element => element
+                .EnumerateArray()
+                .Select(item => item.ValueKind == JsonValueKind.String ? item.GetString() : item.ToString())
+                .Where(item => !string.IsNullOrWhiteSpace(item))
+                .Select(item => item!)
+                .ToArray(),
+            string text => [text],
+            _ => null
+        };
+    }
+
+    private static object? UnwrapJsonElement(object? value)
+    {
+        return value is JsonElement element
+            ? JsonSerializer.Deserialize<object?>(element.GetRawText())
+            : value;
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatReActAgent.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatReActAgent.cs
@@ -1,0 +1,117 @@
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// A ReAct-style agent built on top of <see cref="GigaChatChatCompletionService"/>.
+/// </summary>
+public sealed class GigaChatReActAgent
+{
+    private readonly GigaChatChatCompletionService _service;
+    private readonly GigaChatReActAgentOptions _options;
+    private readonly IGigaChatAgentThreadStore? _threadStore;
+
+    internal GigaChatReActAgent(
+        IGigaChatClient client,
+        Kernel kernel,
+        GigaChatReActAgentOptions options,
+        IGigaChatAgentThreadStore? threadStore = null)
+    {
+        _service = new GigaChatChatCompletionService(client, options.ModelId);
+        Kernel = kernel;
+        _options = options;
+        _threadStore = threadStore;
+    }
+
+    /// <summary>The underlying Semantic Kernel instance with registered plugins.</summary>
+    public Kernel Kernel { get; }
+
+    /// <summary>Creates a new <see cref="GigaChatReActAgent"/> using the fluent builder.</summary>
+    public static GigaChatReActAgent Create(Action<GigaChatReActAgentBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var builder = new GigaChatReActAgentBuilder();
+        configure(builder);
+        return builder.Build();
+    }
+
+    /// <summary>Runs the agent on a single user message and returns the result with step trace.</summary>
+    public Task<GigaChatAgentRunResult> InvokeAsync(
+        string message,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(message));
+        return InvokeAsync(BuildHistory(message), cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the agent, resuming from a stored thread and saving the updated thread after the run.
+    /// </summary>
+    public async Task<GigaChatAgentRunResult> InvokeAsync(
+        string message,
+        string threadId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(message));
+        if (string.IsNullOrWhiteSpace(threadId))
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(threadId));
+
+        if (_threadStore is null)
+            throw new InvalidOperationException(
+                "Thread store is not configured. Call UseThreadStore() on the builder.");
+
+        var thread = await _threadStore.LoadAsync(threadId, cancellationToken);
+        var history = thread?.History.ToList() ?? [];
+
+        if (history.Count == 0 && !string.IsNullOrWhiteSpace(_options.Instructions))
+            history.Insert(0, new ChatMessageContent(AuthorRole.System, _options.Instructions));
+
+        history.Add(new ChatMessageContent(AuthorRole.User, message));
+
+        var result = await InvokeAsync((IReadOnlyList<ChatMessageContent>)history, cancellationToken);
+
+        var updatedHistory = history.Concat(result.FullRunMessages).ToList();
+        var updatedSteps = (thread?.Steps ?? []).Concat(result.Steps).ToList();
+
+        await _threadStore.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = threadId,
+            History = updatedHistory,
+            Steps = updatedSteps
+        }, cancellationToken);
+
+        return result;
+    }
+
+    /// <summary>Runs the agent on a pre-built chat history and returns the result with step trace.</summary>
+    public Task<GigaChatAgentRunResult> InvokeAsync(
+        IReadOnlyList<ChatMessageContent> history,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(history);
+
+        var settings = new GigaChatPromptExecutionSettings
+        {
+            FunctionChoiceBehavior = Kernel.Plugins.Count > 0
+                ? FunctionChoiceBehavior.Auto()
+                : FunctionChoiceBehavior.None(),
+            MaxToolCalls = _options.MaxToolCalls,
+            Temperature = _options.Temperature,
+            ToolSafety = _options.ToolSafety
+        };
+
+        return _service.RunWithStepsAsync(history, settings, Kernel, cancellationToken);
+    }
+
+    private IReadOnlyList<ChatMessageContent> BuildHistory(string message)
+    {
+        var history = new List<ChatMessageContent>();
+        if (!string.IsNullOrWhiteSpace(_options.Instructions))
+            history.Add(new ChatMessageContent(AuthorRole.System, _options.Instructions));
+        history.Add(new ChatMessageContent(AuthorRole.User, message));
+        return history;
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatReActAgentBuilder.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatReActAgentBuilder.cs
@@ -1,0 +1,126 @@
+using Microsoft.SemanticKernel;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Fluent builder for <see cref="GigaChatReActAgent"/>.</summary>
+public sealed class GigaChatReActAgentBuilder
+{
+    private IGigaChatClient? _client;
+    private string? _instructions;
+    private int _maxToolCalls = 8;
+    private double _temperature = 0.1;
+    private string? _modelId;
+    private GigaChatToolSafetyOptions? _toolSafety;
+    private IGigaChatAgentThreadStore? _threadStore;
+    private readonly List<(object Plugin, string Name)> _plugins = [];
+
+    /// <summary>Sets the <see cref="IGigaChatClient"/> used for completions.</summary>
+    public GigaChatReActAgentBuilder UseClient(IGigaChatClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
+        return this;
+    }
+
+    /// <summary>Creates an internal <see cref="GigaChatClient"/> from settings.</summary>
+    public GigaChatReActAgentBuilder UseSettings(Settings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        _client = new GigaChatClient(settings);
+        return this;
+    }
+
+    /// <summary>Sets the system instructions prepended to every run.</summary>
+    public GigaChatReActAgentBuilder WithInstructions(string instructions)
+    {
+        ArgumentNullException.ThrowIfNull(instructions);
+        _instructions = instructions;
+        return this;
+    }
+
+    /// <summary>Overrides the maximum tool calls per run. Must be non-negative.</summary>
+    public GigaChatReActAgentBuilder WithMaxToolCalls(int count)
+    {
+        if (count < 0)
+            throw new ArgumentOutOfRangeException(nameof(count), "Maximum tool calls cannot be negative.");
+        _maxToolCalls = count;
+        return this;
+    }
+
+    /// <summary>Overrides the sampling temperature.</summary>
+    public GigaChatReActAgentBuilder WithTemperature(double temperature)
+    {
+        _temperature = temperature;
+        return this;
+    }
+
+    /// <summary>Overrides the GigaChat model.</summary>
+    public GigaChatReActAgentBuilder WithModelId(string modelId)
+    {
+        _modelId = modelId;
+        return this;
+    }
+
+    /// <summary>Sets tool safety and error-handling options.</summary>
+    public GigaChatReActAgentBuilder WithToolSafety(GigaChatToolSafetyOptions options)
+    {
+        _toolSafety = options;
+        return this;
+    }
+
+    /// <summary>Sets the thread store for multi-turn conversation persistence.</summary>
+    public GigaChatReActAgentBuilder UseThreadStore(IGigaChatAgentThreadStore store)
+    {
+        _threadStore = store;
+        return this;
+    }
+
+    /// <summary>Registers a plugin for auto-invocation.</summary>
+    public GigaChatReActAgentBuilder AddPlugin(object plugin, string pluginName)
+    {
+        ArgumentNullException.ThrowIfNull(plugin);
+        if (string.IsNullOrWhiteSpace(pluginName))
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(pluginName));
+        if (_plugins.Any(p => string.Equals(p.Name, pluginName, StringComparison.Ordinal)))
+            throw new ArgumentException($"A plugin named '{pluginName}' has already been added.", nameof(pluginName));
+        _plugins.Add((plugin, pluginName));
+        return this;
+    }
+
+    /// <summary>Registers a pre-built <see cref="KernelPlugin"/>.</summary>
+    public GigaChatReActAgentBuilder AddKernelPlugin(KernelPlugin plugin)
+    {
+        ArgumentNullException.ThrowIfNull(plugin);
+        if (_plugins.Any(p => string.Equals(p.Name, plugin.Name, StringComparison.Ordinal)))
+            throw new ArgumentException($"A plugin named '{plugin.Name}' has already been added.", nameof(plugin));
+        _plugins.Add((plugin, plugin.Name));
+        return this;
+    }
+
+    internal GigaChatReActAgent Build()
+    {
+        if (_client is null)
+            throw new InvalidOperationException(
+                "A GigaChat client is required. Call UseClient() or UseSettings() before building.");
+
+        var options = new GigaChatReActAgentOptions
+        {
+            MaxToolCalls = _maxToolCalls,
+            Temperature = _temperature,
+            Instructions = _instructions,
+            ToolSafety = _toolSafety,
+            ModelId = _modelId
+        };
+
+        var kernel = Kernel.CreateBuilder().Build();
+        foreach (var (plugin, name) in _plugins)
+        {
+            if (plugin is KernelPlugin kernelPlugin)
+                kernel.Plugins.Add(kernelPlugin);
+            else
+                kernel.Plugins.AddFromObject(plugin, name);
+        }
+
+        return new GigaChatReActAgent(_client, kernel, options, _threadStore);
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatReActAgentOptions.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatReActAgentOptions.cs
@@ -1,0 +1,20 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Options used when running a GigaChat ReAct agent.</summary>
+public sealed class GigaChatReActAgentOptions
+{
+    /// <summary>Maximum number of tool calls per agent run. Defaults to 8.</summary>
+    public int MaxToolCalls { get; init; } = 8;
+
+    /// <summary>Sampling temperature. Defaults to 0.1 for stable tool use.</summary>
+    public double Temperature { get; init; } = 0.1;
+
+    /// <summary>System instructions injected at the start of every run.</summary>
+    public string? Instructions { get; init; }
+
+    /// <summary>Tool safety and error policy. Null means FailFast with no truncation.</summary>
+    public GigaChatToolSafetyOptions? ToolSafety { get; init; }
+
+    /// <summary>Optional GigaChat model override.</summary>
+    public string? ModelId { get; init; }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatReActInstructions.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatReActInstructions.cs
@@ -1,0 +1,53 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Ready-made system instruction templates for GigaChat ReAct-style agents.</summary>
+public static class GigaChatReActInstructions
+{
+    /// <summary>General-purpose agent instructions in Russian.</summary>
+    public const string DefaultRussian = """
+        Ты — умный помощник с доступом к инструментам.
+        Когда для ответа нужны данные — используй инструмент. Не придумывай результаты инструментов.
+        Если инструмент вернул ошибку — сообщи пользователю и предложи альтернативу.
+        Если ответ не требует инструмента — отвечай напрямую.
+        Когда инструмент вернул результат — используй его в ответе.
+        Уточняй у пользователя только если данных действительно недостаточно.
+        Давай лаконичные финальные ответы без лишних пояснений.
+        """;
+
+    /// <summary>General-purpose agent instructions in English.</summary>
+    public const string DefaultEnglish = """
+        You are an intelligent assistant with access to tools.
+        Use a tool when you need data to answer — never fabricate tool results.
+        If a tool returns an error, report it honestly and suggest an alternative.
+        If no tool is needed, answer directly.
+        When a tool returns a result, incorporate it into your answer.
+        Ask the user for clarification only when you genuinely lack required information.
+        Give concise final answers without unnecessary exposition.
+        """;
+
+    /// <summary>Aggressive tool-use profile: always call a tool before answering.</summary>
+    public const string ToolFirst = """
+        You must use at least one tool before providing a final answer, unless the user asks a purely conversational question.
+        Never answer from memory when a tool can provide current or authoritative data.
+        Tool results are ground truth — do not contradict them.
+        If a tool fails, try an alternative tool or clearly state you cannot answer.
+        """;
+
+    /// <summary>Safe read-only research profile: no mutations, no side effects.</summary>
+    public const string ReadOnlyResearch = """
+        You are a research assistant with read-only tool access.
+        You may only use tools that retrieve or summarize information — never tools that create, modify, or delete data.
+        If a tool would cause a side effect, refuse to call it and explain why.
+        Cite which tools you used and what they returned in your answer.
+        """;
+
+    /// <summary>Customer support profile with multi-tool escalation flow.</summary>
+    public const string SupportAgent = """
+        You are a customer support agent with access to lookup tools.
+        Always look up the customer's account or ticket before answering.
+        Use tools to retrieve current status — do not guess or rely on prior knowledge.
+        Escalate to a human agent if tools cannot resolve the issue.
+        Keep your tone professional and empathetic.
+        Summarize what you found and what action was taken or recommended.
+        """;
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatSemanticKernelOptions.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatSemanticKernelOptions.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// Options for registering a GigaChat-backed Semantic Kernel in dependency injection.
+/// </summary>
+public sealed class GigaChatSemanticKernelOptions
+{
+    /// <summary>
+    /// Optional Semantic Kernel service id for keyed <see cref="Microsoft.SemanticKernel.ChatCompletion.IChatCompletionService"/> registration.
+    /// </summary>
+    public string? ServiceId { get; set; }
+
+    /// <summary>
+    /// Default model id used by the registered GigaChat chat completion service.
+    /// </summary>
+    public string? ModelId { get; set; }
+
+    /// <summary>
+    /// Provider-aware default model id factory. When set, it takes precedence over <see cref="ModelId"/>.
+    /// </summary>
+    public Func<IServiceProvider, string?>? ModelIdFactory { get; set; }
+
+    /// <summary>
+    /// Optional endpoint metadata used by Semantic Kernel service attributes.
+    /// </summary>
+    public string? Endpoint { get; set; }
+
+    /// <summary>
+    /// Provider-aware endpoint metadata factory. When set, it takes precedence over <see cref="Endpoint"/>.
+    /// </summary>
+    public Func<IServiceProvider, string?>? EndpointFactory { get; set; }
+
+    /// <summary>
+    /// Lifetime for the registered <see cref="Kernel"/> and chat completion service.
+    /// </summary>
+    public ServiceLifetime Lifetime { get; set; } = ServiceLifetime.Singleton;
+
+    /// <summary>
+    /// Optional callback that customizes the built <see cref="Kernel"/>, for example by adding plugins.
+    /// </summary>
+    public Action<IServiceProvider, Kernel>? ConfigureKernel { get; set; }
+
+    internal string? ResolveModelId(IServiceProvider provider)
+    {
+        return ModelIdFactory?.Invoke(provider) ?? ModelId;
+    }
+
+    internal string? ResolveEndpoint(IServiceProvider provider)
+    {
+        return EndpointFactory?.Invoke(provider) ?? Endpoint;
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatServiceCollectionExtensions.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatServiceCollectionExtensions.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// Dependency injection registration helpers for GigaChat-backed Semantic Kernel services.
+/// </summary>
+public static class GigaChatServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a <see cref="Kernel"/> and <see cref="IChatCompletionService"/> backed by an existing <see cref="IGigaChatClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// Register <see cref="IGigaChatClient"/> first, for example through <c>GigaChat.Net.AspNetCore</c>
+    /// <c>AddGigaChat(...)</c> or by adding your own SDK client registration.
+    /// </remarks>
+    public static IServiceCollection AddGigaChatSemanticKernel(
+        this IServiceCollection services,
+        Action<GigaChatSemanticKernelOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new GigaChatSemanticKernelOptions();
+        configureOptions?.Invoke(options);
+        ValidateOptions(options);
+
+        AddKernel(services, options);
+        AddChatCompletionService(services, options);
+
+        return services;
+    }
+
+    private static void AddKernel(IServiceCollection services, GigaChatSemanticKernelOptions options)
+    {
+        services.Add(ServiceDescriptor.Describe(
+            typeof(Kernel),
+            provider => CreateKernel(provider, options),
+            options.Lifetime));
+    }
+
+    private static Kernel CreateKernel(IServiceProvider provider, GigaChatSemanticKernelOptions options)
+    {
+        var client = provider.GetRequiredService<IGigaChatClient>();
+        var kernel = Kernel.CreateBuilder()
+            .AddGigaChatChatCompletion(
+                client,
+                serviceId: NormalizeServiceId(options.ServiceId),
+                modelId: options.ResolveModelId(provider),
+                endpoint: options.ResolveEndpoint(provider))
+            .Build();
+
+        options.ConfigureKernel?.Invoke(provider, kernel);
+        return kernel;
+    }
+
+    private static void AddChatCompletionService(IServiceCollection services, GigaChatSemanticKernelOptions options)
+    {
+        var serviceId = NormalizeServiceId(options.ServiceId);
+        if (serviceId is null)
+        {
+            AddByLifetime<IChatCompletionService>(
+                services,
+                provider => provider
+                    .GetRequiredService<Kernel>()
+                    .Services
+                    .GetRequiredService<IChatCompletionService>(),
+                options.Lifetime);
+            return;
+        }
+
+        AddKeyedByLifetime<IChatCompletionService>(
+            services,
+            serviceId,
+            provider => provider
+                .GetRequiredService<Kernel>()
+                .Services
+                .GetRequiredKeyedService<IChatCompletionService>(serviceId),
+            options.Lifetime);
+    }
+
+    private static void AddByLifetime<TService>(
+        IServiceCollection services,
+        Func<IServiceProvider, TService> factory,
+        ServiceLifetime lifetime)
+        where TService : class
+    {
+        switch (lifetime)
+        {
+            case ServiceLifetime.Singleton:
+                services.AddSingleton(factory);
+                break;
+            case ServiceLifetime.Scoped:
+                services.AddScoped(factory);
+                break;
+            case ServiceLifetime.Transient:
+                services.AddTransient(factory);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, "Unsupported service lifetime.");
+        }
+    }
+
+    private static void AddKeyedByLifetime<TService>(
+        IServiceCollection services,
+        string serviceId,
+        Func<IServiceProvider, TService> factory,
+        ServiceLifetime lifetime)
+        where TService : class
+    {
+        switch (lifetime)
+        {
+            case ServiceLifetime.Singleton:
+                services.AddKeyedSingleton<TService>(serviceId, (provider, _) => factory(provider));
+                break;
+            case ServiceLifetime.Scoped:
+                services.AddKeyedScoped<TService>(serviceId, (provider, _) => factory(provider));
+                break;
+            case ServiceLifetime.Transient:
+                services.AddKeyedTransient<TService>(serviceId, (provider, _) => factory(provider));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, "Unsupported service lifetime.");
+        }
+    }
+
+    private static void ValidateOptions(GigaChatSemanticKernelOptions options)
+    {
+        if (!Enum.IsDefined(options.Lifetime))
+            throw new ArgumentOutOfRangeException(nameof(options.Lifetime), options.Lifetime, "Unsupported service lifetime.");
+    }
+
+    private static string? NormalizeServiceId(string? serviceId)
+    {
+        return string.IsNullOrWhiteSpace(serviceId) ? null : serviceId;
+    }
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatToolErrorBehavior.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatToolErrorBehavior.cs
@@ -1,0 +1,11 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Controls how the ReAct loop handles tool execution errors.</summary>
+public enum GigaChatToolErrorBehavior
+{
+    /// <summary>Re-throws the exception immediately, stopping the agent run.</summary>
+    FailFast = 0,
+
+    /// <summary>Converts the exception message into a tool observation and continues the loop.</summary>
+    ReturnObservation = 1
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatToolSafetyOptions.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatToolSafetyOptions.cs
@@ -1,0 +1,25 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Tool safety and error-handling options for a GigaChat agent run.</summary>
+public sealed class GigaChatToolSafetyOptions
+{
+    /// <summary>
+    /// How tool execution exceptions are handled.
+    /// Defaults to <see cref="GigaChatToolErrorBehavior.FailFast"/>.
+    /// </summary>
+    public GigaChatToolErrorBehavior ErrorBehavior { get; init; } = GigaChatToolErrorBehavior.FailFast;
+
+    /// <summary>
+    /// Maximum character length of a tool result observation.
+    /// Results exceeding this limit are clipped with "[truncated]" appended.
+    /// Null disables truncation.
+    /// </summary>
+    public int? MaxOutputLength { get; init; }
+
+    /// <summary>
+    /// Set of allowed plugin names. When non-null, calls to plugins outside this set are
+    /// rejected before invocation. Null allows all registered plugins. A function with no
+    /// plugin name is treated as not allowed when this set is non-null.
+    /// </summary>
+    public IReadOnlySet<string>? AllowedPlugins { get; init; }
+}

--- a/src/GigaChat.Net.SemanticKernel/IGigaChatAgentThreadStore.cs
+++ b/src/GigaChat.Net.SemanticKernel/IGigaChatAgentThreadStore.cs
@@ -1,0 +1,14 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Persistence contract for agent conversation threads.</summary>
+public interface IGigaChatAgentThreadStore
+{
+    /// <summary>Saves or replaces the thread by its <see cref="GigaChatAgentThread.ThreadId"/>.</summary>
+    Task SaveAsync(GigaChatAgentThread thread, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the thread, or <see langword="null"/> if not found.</summary>
+    Task<GigaChatAgentThread?> LoadAsync(string threadId, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes the thread. No-op if the thread does not exist.</summary>
+    Task DeleteAsync(string threadId, CancellationToken cancellationToken = default);
+}

--- a/src/GigaChat.Net.SemanticKernel/InMemoryGigaChatAgentThreadStore.cs
+++ b/src/GigaChat.Net.SemanticKernel/InMemoryGigaChatAgentThreadStore.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// Thread-safe in-memory implementation of <see cref="IGigaChatAgentThreadStore"/>.
+/// Suitable for single-process use; threads are lost when the process exits.
+/// </summary>
+public sealed class InMemoryGigaChatAgentThreadStore : IGigaChatAgentThreadStore
+{
+    private readonly ConcurrentDictionary<string, GigaChatAgentThread> _store =
+        new(StringComparer.Ordinal);
+
+    /// <inheritdoc/>
+    public Task SaveAsync(GigaChatAgentThread thread, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(thread);
+        if (string.IsNullOrWhiteSpace(thread.ThreadId))
+            throw new ArgumentException("ThreadId cannot be null or whitespace.", nameof(thread));
+
+        _store[thread.ThreadId] = thread;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<GigaChatAgentThread?> LoadAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(threadId))
+            throw new ArgumentException("threadId cannot be null or whitespace.", nameof(threadId));
+
+        _store.TryGetValue(threadId, out var thread);
+        return Task.FromResult(thread);
+    }
+
+    /// <inheritdoc/>
+    public Task DeleteAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(threadId))
+            throw new ArgumentException("threadId cannot be null or whitespace.", nameof(threadId));
+
+        _store.TryRemove(threadId, out _);
+        return Task.CompletedTask;
+    }
+}

--- a/src/GigaChat.Net/GigaChat.Net.csproj
+++ b/src/GigaChat.Net/GigaChat.Net.csproj
@@ -8,7 +8,7 @@
     
     <!-- NuGet Package Metadata -->
     <PackageId>GigaChat.Net</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <Authors>GigaChat.Net Contributors</Authors>
     <Description>.NET SDK for GigaChat REST API - a large language model by Sber. Full port of the Python gigachat library.</Description>
     <PackageTags>gigachat;ai;llm;sber;api;sdk;chat;completions;embeddings;streaming</PackageTags>

--- a/tests/GigaChat.Net.Tests/AgentStepTests.cs
+++ b/tests/GigaChat.Net.Tests/AgentStepTests.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class AgentStepTests
+{
+    [Fact]
+    public async Task RunWithStepsAsync_EmitsToolCallAndResultAndFinalStepsInOrder()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_do_work", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "done" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new StepTestPlugin(), "stub");
+
+        var result = await service.RunWithStepsAsync(
+            [new ChatMessageContent(AuthorRole.User, "do work")],
+            new GigaChatPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() },
+            kernel);
+
+        Assert.Equal("done", Assert.Single(result.Messages).Content);
+        Assert.Equal(3, result.Steps.Count);
+
+        var callStep = Assert.IsType<GigaChatToolCallStep>(result.Steps[0]);
+        Assert.Equal("stub_do_work", callStep.ToolName);
+        Assert.Equal(0, callStep.RequestIndex);
+
+        var resultStep = Assert.IsType<GigaChatToolResultStep>(result.Steps[1]);
+        Assert.Equal("stub_do_work", resultStep.ToolName);
+        Assert.Equal("done", resultStep.Result);
+        Assert.Null(resultStep.Exception);
+
+        var finalStep = Assert.IsType<GigaChatAssistantMessageStep>(result.Steps[2]);
+        Assert.Equal("done", finalStep.Content);
+        Assert.NotNull(finalStep.Usage);
+    }
+
+    [Fact]
+    public async Task RunWithStepsAsync_ToolError_ReturnObservation_StepRecordsException()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_throws", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "error handled" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new ThrowingStepPlugin(), "stub");
+
+        var result = await service.RunWithStepsAsync(
+            [new ChatMessageContent(AuthorRole.User, "throw")],
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                ToolSafety = new GigaChatToolSafetyOptions
+                {
+                    ErrorBehavior = GigaChatToolErrorBehavior.ReturnObservation
+                }
+            },
+            kernel);
+
+        var resultStep = Assert.IsType<GigaChatToolResultStep>(result.Steps[1]);
+        Assert.NotNull(resultStep.Exception);
+        Assert.IsType<InvalidOperationException>(resultStep.Exception);
+        Assert.Contains("InvalidOperationException", resultStep.Result);
+    }
+
+    private sealed class StepTestPlugin
+    {
+        [KernelFunction("do_work")]
+        [Description("Does work.")]
+        public string DoWork() => "done";
+    }
+
+    private sealed class ThrowingStepPlugin
+    {
+        [KernelFunction("throws")]
+        [Description("Always throws.")]
+        public string Throws() => throw new InvalidOperationException("boom");
+    }
+}

--- a/tests/GigaChat.Net.Tests/AgentThreadStoreTests.cs
+++ b/tests/GigaChat.Net.Tests/AgentThreadStoreTests.cs
@@ -1,0 +1,205 @@
+using System.ComponentModel;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class AgentThreadStoreTests
+{
+    // ---- InMemoryGigaChatAgentThreadStore unit tests ----
+
+    [Fact]
+    public async Task SaveAndLoad_RoundTrips()
+    {
+        var store = new InMemoryGigaChatAgentThreadStore();
+        var thread = new GigaChatAgentThread
+        {
+            ThreadId = "t1",
+            History = [new ChatMessageContent(AuthorRole.User, "hello")]
+        };
+
+        await store.SaveAsync(thread);
+        var loaded = await store.LoadAsync("t1");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("t1", loaded.ThreadId);
+        Assert.Single(loaded.History);
+    }
+
+    [Fact]
+    public async Task Load_UnknownThread_ReturnsNull()
+    {
+        var store = new InMemoryGigaChatAgentThreadStore();
+        var result = await store.LoadAsync("missing");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesThread()
+    {
+        var store = new InMemoryGigaChatAgentThreadStore();
+        await store.SaveAsync(new GigaChatAgentThread { ThreadId = "t1" });
+        await store.DeleteAsync("t1");
+        Assert.Null(await store.LoadAsync("t1"));
+    }
+
+    [Fact]
+    public async Task Delete_NonExistentThread_DoesNotThrow()
+    {
+        var store = new InMemoryGigaChatAgentThreadStore();
+        await store.DeleteAsync("no-such-thread");
+    }
+
+    [Fact]
+    public async Task Save_OverwritesExistingThread()
+    {
+        var store = new InMemoryGigaChatAgentThreadStore();
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t1",
+            History = [new ChatMessageContent(AuthorRole.User, "v1")]
+        });
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t1",
+            History = [new ChatMessageContent(AuthorRole.User, "v2")]
+        });
+
+        var loaded = await store.LoadAsync("t1");
+        Assert.Equal("v2", loaded!.History[0].Content);
+    }
+
+    // ---- Integration: GigaChatReActAgent with thread store ----
+
+    [Fact]
+    public async Task Agent_ThreadId_AccumulatesHistoryAcrossRuns()
+    {
+        var handler = new RecordingHandler();
+        // First run response
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "reply1" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        // Second run response
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "reply2" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var store = new InMemoryGigaChatAgentThreadStore();
+
+        var agent = GigaChatReActAgent.Create(builder =>
+        {
+            builder.UseClient(client);
+            builder.WithInstructions(GigaChatReActInstructions.DefaultEnglish);
+            builder.UseThreadStore(store);
+        });
+
+        await agent.InvokeAsync("turn 1", "thread-a");
+        await agent.InvokeAsync("turn 2", "thread-a");
+
+        var thread = await store.LoadAsync("thread-a");
+        Assert.NotNull(thread);
+        // system + turn1-user + reply1 + turn2-user + reply2
+        Assert.Equal(5, thread!.History.Count);
+        Assert.Equal("reply2", thread.History[^1].Content);
+    }
+
+    [Fact]
+    public async Task Agent_ThreadId_IncludesToolCallMessagesInHistory()
+    {
+        // Verifies B2: intermediate function_call + function_result messages must be
+        // persisted so the next turn receives the full tool-use context.
+        var handler = new RecordingHandler();
+        // Turn 1: tool call then final reply
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_do_work", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "tool done" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        // Turn 2: simple reply
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "turn2 reply" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 3, "model": "GigaChat",
+          "usage": { "prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var store = new InMemoryGigaChatAgentThreadStore();
+
+        var agent = GigaChatReActAgent.Create(builder =>
+        {
+            builder.UseClient(client);
+            builder.WithInstructions("System.");
+            builder.UseThreadStore(store);
+            builder.AddPlugin(new ThreadToolPlugin(), "stub");
+        });
+
+        await agent.InvokeAsync("turn 1", "thread-b");
+
+        var thread = await store.LoadAsync("thread-b");
+        Assert.NotNull(thread);
+        // system + user + assistant_functioncall + tool_result + assistant_reply
+        Assert.Equal(5, thread!.History.Count);
+        Assert.Equal(AuthorRole.System,    thread.History[0].Role);
+        Assert.Equal(AuthorRole.User,      thread.History[1].Role);
+        Assert.Equal(AuthorRole.Assistant, thread.History[2].Role);  // function_call
+        Assert.Equal(AuthorRole.Tool,      thread.History[3].Role);  // tool result
+        Assert.Equal(AuthorRole.Assistant, thread.History[4].Role);  // final reply
+        Assert.Equal("tool done", thread.History[4].Content);
+    }
+
+    [Fact]
+    public async Task Agent_WithoutThreadStore_InvokeWithThreadId_Throws()
+    {
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler());
+
+        var agent = GigaChatReActAgent.Create(builder =>
+        {
+            builder.UseClient(client);
+            builder.WithInstructions("test");
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            agent.InvokeAsync("hello", "thread-1"));
+    }
+
+    private sealed class ThreadToolPlugin
+    {
+        [System.ComponentModel.Description("Does work.")]
+        [Microsoft.SemanticKernel.KernelFunction("do_work")]
+        public string DoWork() => "done";
+    }
+}

--- a/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
+++ b/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="..\..\src\GigaChat.Net\Compatibility\RequiredMemberAttributes.cs" Link="Compatibility\RequiredMemberAttributes.cs" />
     <ProjectReference Include="..\..\src\GigaChat.Net.AspNetCore\GigaChat.Net.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\GigaChat.Net\GigaChat.Net.csproj" />
+    <ProjectReference Include="..\..\src\GigaChat.Net.SemanticKernel\GigaChat.Net.SemanticKernel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/GigaChat.Net.Tests/ReActAgentBuilderTests.cs
+++ b/tests/GigaChat.Net.Tests/ReActAgentBuilderTests.cs
@@ -1,0 +1,142 @@
+using System.ComponentModel;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+
+namespace GigaChat.Net.Tests;
+
+public class ReActAgentBuilderTests
+{
+    [Fact]
+    public async Task Create_WithMinimalConfig_ProducesWorkingAgent()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "hello" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+
+        var agent = GigaChatReActAgent.Create(builder =>
+        {
+            builder.UseClient(client);
+            builder.WithInstructions(GigaChatReActInstructions.DefaultEnglish);
+        });
+
+        var result = await agent.InvokeAsync("say hello");
+
+        Assert.Equal("hello", Assert.Single(result.Messages).Content);
+    }
+
+    [Fact]
+    public async Task Create_WithPlugin_AutoInvokesTool()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_do_work", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "done" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+
+        var agent = GigaChatReActAgent.Create(builder =>
+        {
+            builder.UseClient(client);
+            builder.WithInstructions("Use tools.");
+            builder.AddPlugin(new BuilderTestPlugin(), "stub");
+        });
+
+        var result = await agent.InvokeAsync("do some work");
+
+        Assert.Equal("done", Assert.Single(result.Messages).Content);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public void Create_WithoutClient_ThrowsInvalidOperationException()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            GigaChatReActAgent.Create(builder =>
+            {
+                builder.WithInstructions("test");
+            }));
+    }
+
+    [Fact]
+    public void Create_WithNegativeMaxToolCalls_ThrowsArgumentOutOfRangeException()
+    {
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            GigaChatReActAgent.Create(builder =>
+            {
+                builder.UseClient(client);
+                builder.WithInstructions("test");
+                builder.WithMaxToolCalls(-1);
+            }));
+    }
+
+    [Fact]
+    public void Create_WithDuplicatePluginName_ThrowsArgumentException()
+    {
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler());
+
+        Assert.Throws<ArgumentException>(() =>
+            GigaChatReActAgent.Create(builder =>
+            {
+                builder.UseClient(client);
+                builder.WithInstructions("test");
+                builder.AddPlugin(new BuilderTestPlugin(), "stub");
+                builder.AddPlugin(new BuilderTestPlugin(), "stub");
+            }));
+    }
+
+    [Fact]
+    public void Kernel_IsAccessibleAfterCreate()
+    {
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler());
+
+        var agent = GigaChatReActAgent.Create(builder =>
+        {
+            builder.UseClient(client);
+            builder.WithInstructions("test");
+            builder.AddPlugin(new BuilderTestPlugin(), "stub");
+        });
+
+        Assert.NotNull(agent.Kernel);
+        Assert.Contains(agent.Kernel.Plugins, p => p.Name == "stub");
+    }
+
+    private sealed class BuilderTestPlugin
+    {
+        [KernelFunction("do_work")]
+        [Description("Does work.")]
+        public string DoWork() => "done";
+    }
+}

--- a/tests/GigaChat.Net.Tests/ReActInstructionTests.cs
+++ b/tests/GigaChat.Net.Tests/ReActInstructionTests.cs
@@ -1,0 +1,51 @@
+using GigaChat.Net.SemanticKernel;
+
+namespace GigaChat.Net.Tests;
+
+public class ReActInstructionTests
+{
+    [Theory]
+    [InlineData(nameof(GigaChatReActInstructions.DefaultRussian))]
+    [InlineData(nameof(GigaChatReActInstructions.DefaultEnglish))]
+    [InlineData(nameof(GigaChatReActInstructions.ToolFirst))]
+    [InlineData(nameof(GigaChatReActInstructions.ReadOnlyResearch))]
+    [InlineData(nameof(GigaChatReActInstructions.SupportAgent))]
+    public void InstructionTemplate_IsNotNullOrWhiteSpace(string name)
+    {
+        var value = (string?)typeof(GigaChatReActInstructions)
+            .GetField(name, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!
+            .GetValue(null);
+
+        Assert.False(string.IsNullOrWhiteSpace(value));
+    }
+
+    [Fact]
+    public void DefaultRussian_ContainsKeywordInRussian()
+    {
+        Assert.Contains("инструмент", GigaChatReActInstructions.DefaultRussian, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DefaultEnglish_DoesNotRequireThoughtPrefix()
+    {
+        Assert.DoesNotContain("Thought:", GigaChatReActInstructions.DefaultEnglish, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReadOnlyResearch_ForbidsModifyingActions()
+    {
+        Assert.Contains("read-only", GigaChatReActInstructions.ReadOnlyResearch, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ToolFirst_MandatesToolCallBeforeAnswer()
+    {
+        Assert.Contains("tool", GigaChatReActInstructions.ToolFirst, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SupportAgent_MentionsEscalation()
+    {
+        Assert.Contains("escalate", GigaChatReActInstructions.SupportAgent, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/GigaChat.Net.Tests/SemanticKernelReActTests.cs
+++ b/tests/GigaChat.Net.Tests/SemanticKernelReActTests.cs
@@ -1,0 +1,200 @@
+using System.ComponentModel;
+using System.Text.Json;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class SemanticKernelReActTests
+{
+    [Fact]
+    public async Task FunctionChoiceNone_DoesNotSendFunctionsToApi()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new StubPlugin(), "stub");
+
+        await service.GetChatMessageContentsAsync(
+            [new ChatMessageContent(AuthorRole.User, "hello")],
+            new GigaChatPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.None() },
+            kernel);
+
+        var request = Assert.Single(handler.Requests);
+        using var body = JsonDocument.Parse(request.Body!);
+        Assert.False(body.RootElement.TryGetProperty("functions", out _));
+    }
+
+    [Fact]
+    public async Task FunctionChoiceAutoManual_ReturnsFunctionCallContentWithoutInvoking()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_do_work", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new StubPlugin(), "stub");
+
+        var response = await service.GetChatMessageContentsAsync(
+            [new ChatMessageContent(AuthorRole.User, "do work")],
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false)
+            },
+            kernel);
+
+        var message = Assert.Single(response);
+        var call = Assert.Single(message.Items.OfType<FunctionCallContent>());
+        Assert.Equal("stub", call.PluginName);
+        Assert.Equal("do_work", call.FunctionName);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task MultiStepToolLoop_ExecutesBothToolsInOrder()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_tool_a", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_tool_b", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "done" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 3, "model": "GigaChat",
+          "usage": { "prompt_tokens": 3, "completion_tokens": 3, "total_tokens": 6 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new TwoToolPlugin(), "stub");
+
+        var response = await service.GetChatMessageContentsAsync(
+            [new ChatMessageContent(AuthorRole.User, "run both tools")],
+            new GigaChatPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() },
+            kernel);
+
+        Assert.Equal("done", Assert.Single(response).Content);
+        Assert.Equal(3, handler.Requests.Count);
+
+        using var thirdBody = JsonDocument.Parse(handler.Requests[2].Body!);
+        var messages = thirdBody.RootElement.GetProperty("messages");
+        Assert.Equal(5, messages.GetArrayLength());
+        Assert.Equal("stub_tool_a", messages[1].GetProperty("function_call").GetProperty("name").GetString());
+        Assert.Equal("stub_tool_b", messages[3].GetProperty("function_call").GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task ToolArguments_DeserializesArrayAndNestedObjectCorrectly()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_complex_args",
+              "arguments": { "tags": ["a","b"], "meta": { "key": "val" }, "count": null } } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        var plugin = new ComplexArgsPlugin();
+        kernel.Plugins.AddFromObject(plugin, "stub");
+
+        await service.GetChatMessageContentsAsync(
+            [new ChatMessageContent(AuthorRole.User, "complex args")],
+            new GigaChatPromptExecutionSettings { FunctionChoiceBehavior = FunctionChoiceBehavior.Auto() },
+            kernel);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.NotNull(plugin.LastTags);
+        Assert.Equal(["a", "b"], plugin.LastTags);
+    }
+
+    [Fact]
+    public async Task ToolLoop_RespectsAndPropagatesCancellationToken()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetChatMessageContentsAsync(
+                [new ChatMessageContent(AuthorRole.User, "hello")],
+                cancellationToken: cts.Token));
+    }
+
+    private sealed class StubPlugin
+    {
+        [KernelFunction("do_work")]
+        public string DoWork() => "done";
+    }
+
+    private sealed class TwoToolPlugin
+    {
+        [KernelFunction("tool_a")]
+        public string ToolA() => "result-a";
+
+        [KernelFunction("tool_b")]
+        public string ToolB() => "result-b";
+    }
+
+    private sealed class ComplexArgsPlugin
+    {
+        public string[]? LastTags { get; private set; }
+
+        [KernelFunction("complex_args")]
+        public string ComplexArgs(
+            [Description("string tags")] string[]? tags,
+            [Description("metadata")] Dictionary<string, string>? meta,
+            [Description("nullable count")] int? count)
+        {
+            LastTags = tags;
+            return "ok";
+        }
+    }
+}

--- a/tests/GigaChat.Net.Tests/SemanticKernelTests.cs
+++ b/tests/GigaChat.Net.Tests/SemanticKernelTests.cs
@@ -1,0 +1,615 @@
+using System.ComponentModel;
+using System.Text.Json;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class SemanticKernelTests
+{
+    [Fact]
+    public async Task ChatCompletionServiceMapsSemanticKernelHistoryToGigaChatRequest()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client, "GigaChat-Pro");
+        ChatHistory history =
+        [
+            new ChatMessageContent(AuthorRole.System, "rules"),
+            new ChatMessageContent(AuthorRole.User, "hello")
+        ];
+
+        var response = await service.GetChatMessageContentsAsync(
+            history,
+            new GigaChatPromptExecutionSettings
+            {
+                Temperature = 0.2,
+                TopP = 0.9,
+                MaxTokens = 128,
+                ProfanityCheck = false,
+                Flags = ["trace"],
+                ReasoningEffort = "low"
+            });
+
+        Assert.Single(response);
+        Assert.Equal(AuthorRole.Assistant, response[0].Role);
+        Assert.StartsWith("GigaChat", response[0].ModelId);
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("/api/v1/chat/completions", request.PathAndQuery);
+
+        using var body = JsonDocument.Parse(request.Body!);
+        Assert.Equal("GigaChat-Pro", body.RootElement.GetProperty("model").GetString());
+        Assert.Equal("system", body.RootElement.GetProperty("messages")[0].GetProperty("role").GetString());
+        Assert.Equal("rules", body.RootElement.GetProperty("messages")[0].GetProperty("content").GetString());
+        Assert.Equal("user", body.RootElement.GetProperty("messages")[1].GetProperty("role").GetString());
+        Assert.Equal(0.2, body.RootElement.GetProperty("temperature").GetDouble());
+        Assert.Equal(0.9, body.RootElement.GetProperty("top_p").GetDouble());
+        Assert.Equal(128, body.RootElement.GetProperty("max_tokens").GetInt32());
+        Assert.False(body.RootElement.GetProperty("profanity_check").GetBoolean());
+        Assert.Equal("trace", body.RootElement.GetProperty("flags")[0].GetString());
+        Assert.Equal("low", body.RootElement.GetProperty("reasoning_effort").GetString());
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceMapsSemanticKernelFunctionsToGigaChatRequest()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new WeatherPlugin(), "weather");
+        ChatHistory history = [new ChatMessageContent(AuthorRole.User, "weather in Tokyo")];
+
+        await service.GetChatMessageContentsAsync(
+            history,
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+            },
+            kernel);
+
+        var request = Assert.Single(handler.Requests);
+        using var body = JsonDocument.Parse(request.Body!);
+        Assert.Equal("auto", body.RootElement.GetProperty("function_call").GetString());
+
+        var function = Assert.Single(body.RootElement.GetProperty("functions").EnumerateArray());
+        Assert.Equal("weather_get_weather", function.GetProperty("name").GetString());
+        Assert.Equal("Gets current weather for a city.", function.GetProperty("description").GetString());
+
+        var parameters = function.GetProperty("parameters");
+        Assert.Equal("object", parameters.GetProperty("type").GetString());
+        Assert.Equal("city", Assert.Single(parameters.GetProperty("required").EnumerateArray()).GetString());
+
+        var city = parameters
+            .GetProperty("properties")
+            .GetProperty("city");
+        Assert.Equal("string", city.GetProperty("type").GetString());
+        Assert.Equal("City name.", city.GetProperty("description").GetString());
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceAutoInvokesSemanticKernelFunctions()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "function_call": {
+                  "name": "weather_get_weather",
+                  "arguments": { "city": "Tokyo" }
+                }
+              },
+              "index": 0,
+              "finish_reason": "function_call"
+            }
+          ],
+          "created": 1,
+          "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "Tokyo is 22 C"
+              },
+              "index": 0,
+              "finish_reason": "stop"
+            }
+          ],
+          "created": 2,
+          "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new WeatherPlugin(), "weather");
+        ChatHistory history = [new ChatMessageContent(AuthorRole.User, "weather in Tokyo")];
+
+        var response = await service.GetChatMessageContentsAsync(
+            history,
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+            },
+            kernel);
+
+        Assert.Equal("Tokyo is 22 C", Assert.Single(response).Content);
+        Assert.Equal(2, handler.Requests.Count);
+
+        using var secondBody = JsonDocument.Parse(handler.Requests[1].Body!);
+        var messages = secondBody.RootElement.GetProperty("messages");
+        Assert.Equal("assistant", messages[1].GetProperty("role").GetString());
+        Assert.Equal("weather_get_weather", messages[1].GetProperty("function_call").GetProperty("name").GetString());
+        Assert.Equal("function", messages[2].GetProperty("role").GetString());
+        Assert.Equal("weather_get_weather", messages[2].GetProperty("name").GetString());
+        Assert.Equal("Tokyo is 22 C", messages[2].GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceRejectsUnknownSemanticKernelFunctionCall()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "function_call": {
+                  "name": "unknown",
+                  "arguments": { }
+                }
+              },
+              "index": 0,
+              "finish_reason": "function_call"
+            }
+          ],
+          "created": 1,
+          "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new WeatherPlugin(), "weather");
+
+        var exception = await Assert.ThrowsAsync<GigaChatException>(
+            () => service.GetChatMessageContentsAsync(
+                [new ChatMessageContent(AuthorRole.User, "call a tool")],
+                new GigaChatPromptExecutionSettings
+                {
+                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+                },
+                kernel));
+
+        Assert.Contains("Unknown Semantic Kernel function call 'unknown'", exception.Message);
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceLimitsSemanticKernelFunctionCalls()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "function_call": {
+                  "name": "weather_get_weather",
+                  "arguments": { "city": "Tokyo" }
+                }
+              },
+              "index": 0,
+              "finish_reason": "function_call"
+            }
+          ],
+          "created": 1,
+          "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new WeatherPlugin(), "weather");
+
+        var exception = await Assert.ThrowsAsync<GigaChatException>(
+            () => service.GetChatMessageContentsAsync(
+                [new ChatMessageContent(AuthorRole.User, "call a tool")],
+                new GigaChatPromptExecutionSettings
+                {
+                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                    MaxToolCalls = 0
+                },
+                kernel));
+
+        Assert.Contains("exceeded the maximum of 0", exception.Message);
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceMapsSemanticKernelFunctionContentItemsToGigaChatMessages()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        var functionCall = new FunctionCallContent(
+            "get_weather",
+            "weather",
+            "call-1",
+            new KernelArguments { ["city"] = "Tokyo" });
+        var assistant = new ChatMessageContent(AuthorRole.Assistant, string.Empty);
+        assistant.Items.Add(functionCall);
+        var functionResult = new FunctionResultContent(
+            "get_weather",
+            "weather",
+            "call-1",
+            "Tokyo is 22 C");
+        ChatHistory history =
+        [
+            new ChatMessageContent(AuthorRole.User, "weather in Tokyo"),
+            assistant,
+            functionResult.ToChatMessage()
+        ];
+
+        await service.GetChatMessageContentsAsync(history);
+
+        var request = Assert.Single(handler.Requests);
+        using var body = JsonDocument.Parse(request.Body!);
+        var messages = body.RootElement.GetProperty("messages");
+        Assert.Equal("assistant", messages[1].GetProperty("role").GetString());
+        Assert.Equal("weather_get_weather", messages[1].GetProperty("function_call").GetProperty("name").GetString());
+        Assert.Equal("Tokyo", messages[1].GetProperty("function_call").GetProperty("arguments").GetProperty("city").GetString());
+        Assert.Equal("function", messages[2].GetProperty("role").GetString());
+        Assert.Equal("weather_get_weather", messages[2].GetProperty("name").GetString());
+        Assert.Equal("Tokyo is 22 C", messages[2].GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceReturnsFunctionCallContentWhenAutoInvokeIsDisabled()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "function_call": {
+                  "name": "weather_get_weather",
+                  "arguments": { "city": "Tokyo" }
+                }
+              },
+              "index": 0,
+              "finish_reason": "function_call"
+            }
+          ],
+          "created": 1,
+          "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new WeatherPlugin(), "weather");
+
+        var response = await service.GetChatMessageContentsAsync(
+            [new ChatMessageContent(AuthorRole.User, "weather in Tokyo")],
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: false)
+            },
+            kernel);
+
+        var message = Assert.Single(response);
+        var call = Assert.Single(message.Items.OfType<FunctionCallContent>());
+        Assert.Equal("weather", call.PluginName);
+        Assert.Equal("get_weather", call.FunctionName);
+        Assert.Equal("Tokyo", call.Arguments!["city"]?.ToString());
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceRejectsUnsupportedSemanticKernelContentItems()
+    {
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler());
+        var service = new GigaChatChatCompletionService(client);
+        var message = new ChatMessageContent(AuthorRole.User, string.Empty);
+        message.Items.Add(new ImageContent(new Uri("https://example.com/image.png")));
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(
+            () => service.GetChatMessageContentsAsync([message]));
+
+        Assert.Contains("ImageContent", exception.Message);
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceOmitsAuthorNameExceptForFunctionMessages()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        ChatHistory history =
+        [
+            new ChatMessageContent(AuthorRole.System, "rules") { AuthorName = "planner" },
+            new ChatMessageContent(AuthorRole.User, "hello") { AuthorName = "alice" },
+            new ChatMessageContent(AuthorRole.Assistant, "prior answer") { AuthorName = "agent" },
+            new ChatMessageContent(AuthorRole.Tool, "tool result") { AuthorName = "lookup" }
+        ];
+
+        await service.GetChatMessageContentsAsync(history);
+
+        var request = Assert.Single(handler.Requests);
+        using var body = JsonDocument.Parse(request.Body!);
+        var messages = body.RootElement.GetProperty("messages");
+        Assert.False(messages[0].TryGetProperty("name", out _));
+        Assert.False(messages[1].TryGetProperty("name", out _));
+        Assert.False(messages[2].TryGetProperty("name", out _));
+        Assert.Equal("function", messages[3].GetProperty("role").GetString());
+        Assert.Equal("lookup", messages[3].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceMapsStreamingChunks()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueText(TestData.Fixture("chat_completion.stream"), "text/event-stream");
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        ChatHistory history = [new ChatMessageContent(AuthorRole.User, "hello")];
+
+        var chunks = new List<StreamingChatMessageContent>();
+        await foreach (var chunk in service.GetStreamingChatMessageContentsAsync(history))
+            chunks.Add(chunk);
+
+        Assert.Equal(3, chunks.Count);
+        Assert.Equal(AuthorRole.Assistant, chunks[0].Role);
+        Assert.All(chunks.Skip(1), chunk => Assert.Null(chunk.Role));
+        Assert.All(chunks, chunk => Assert.StartsWith("GigaChat", chunk.ModelId));
+        Assert.Contains(chunks, chunk => !string.IsNullOrWhiteSpace(chunk.Content));
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal("text/event-stream", request.Accept);
+        using var body = JsonDocument.Parse(request.Body!);
+        Assert.True(body.RootElement.GetProperty("stream").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ChatCompletionServiceStreamsFinalMessageAfterSemanticKernelFunctionCalls()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "function_call": {
+                  "name": "weather_get_weather",
+                  "arguments": { "city": "Tokyo" }
+                }
+              },
+              "index": 0,
+              "finish_reason": "function_call"
+            }
+          ],
+          "created": 1,
+          "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "Tokyo is 22 C"
+              },
+              "index": 0,
+              "finish_reason": "stop"
+            }
+          ],
+          "created": 2,
+          "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new WeatherPlugin(), "weather");
+        var chunks = new List<StreamingChatMessageContent>();
+
+        await foreach (var chunk in service.GetStreamingChatMessageContentsAsync(
+                           [new ChatMessageContent(AuthorRole.User, "weather in Tokyo")],
+                           new GigaChatPromptExecutionSettings
+                           {
+                               FunctionChoiceBehavior = FunctionChoiceBehavior.Auto()
+                           },
+                           kernel))
+        {
+            chunks.Add(chunk);
+        }
+
+        var finalChunk = Assert.Single(chunks);
+        Assert.Equal(AuthorRole.Assistant, finalChunk.Role);
+        Assert.Equal("Tokyo is 22 C", finalChunk.Content);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.NotEqual("text/event-stream", handler.Requests[0].Accept);
+        Assert.NotEqual("text/event-stream", handler.Requests[1].Accept);
+    }
+
+    [Fact]
+    public void KernelBuilderRegistersGigaChatChatCompletionService()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            handler);
+
+        var kernel = Kernel.CreateBuilder()
+            .AddGigaChatChatCompletion(client, modelId: "GigaChat-Pro", endpoint: TestData.BaseUrl)
+            .Build();
+
+        var service = kernel.Services.GetRequiredService<IChatCompletionService>();
+
+        Assert.IsType<GigaChatChatCompletionService>(service);
+        Assert.Equal("GigaChat-Pro", service.Attributes["ModelId"]);
+        Assert.Equal(TestData.BaseUrl, service.Attributes["Endpoint"]);
+    }
+
+    [Fact]
+    public void KernelBuilderRegistersKeyedGigaChatChatCompletionService()
+    {
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler());
+
+        var kernel = Kernel.CreateBuilder()
+            .AddGigaChatChatCompletion(client, serviceId: "gigachat", modelId: "GigaChat-Pro")
+            .Build();
+
+        var service = kernel.Services.GetRequiredKeyedService<IChatCompletionService>("gigachat");
+
+        Assert.IsType<GigaChatChatCompletionService>(service);
+        Assert.Equal("GigaChat-Pro", service.Attributes["ModelId"]);
+    }
+
+    [Fact]
+    public void ServiceCollectionRegistersSemanticKernelFromExistingGigaChatClient()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new KernelRegistrationConfig("GigaChat-Pro", TestData.BaseUrl));
+        services.AddSingleton<IGigaChatClient>(_ => new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler()));
+
+        services.AddGigaChatSemanticKernel(options =>
+        {
+            options.ModelIdFactory = provider => provider.GetRequiredService<KernelRegistrationConfig>().ModelId;
+            options.EndpointFactory = provider => provider.GetRequiredService<KernelRegistrationConfig>().Endpoint;
+            options.ConfigureKernel = (_, kernel) =>
+                kernel.Plugins.AddFromObject(new WeatherPlugin(), "weather");
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var kernel = provider.GetRequiredService<Kernel>();
+        var service = provider.GetRequiredService<IChatCompletionService>();
+
+        Assert.IsType<GigaChatChatCompletionService>(service);
+        Assert.Equal("GigaChat-Pro", service.Attributes["ModelId"]);
+        Assert.Equal(TestData.BaseUrl, service.Attributes["Endpoint"]);
+        Assert.Contains(kernel.Plugins, plugin => plugin.Name == "weather");
+    }
+
+    [Fact]
+    public void ServiceCollectionRegistersKeyedSemanticKernelChatCompletionService()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IGigaChatClient>(_ => new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl },
+            new RecordingHandler()));
+
+        services.AddGigaChatSemanticKernel(options =>
+        {
+            options.ServiceId = "gigachat";
+            options.ModelId = "GigaChat-Max";
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var service = provider.GetRequiredKeyedService<IChatCompletionService>("gigachat");
+
+        Assert.IsType<GigaChatChatCompletionService>(service);
+        Assert.Equal("GigaChat-Max", service.Attributes["ModelId"]);
+        Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<IChatCompletionService>());
+    }
+
+    [Fact]
+    public void GenericPromptExecutionSettingsExtensionDataMapsToGigaChatSettings()
+    {
+        var settings = GigaChatPromptExecutionSettings.FromExecutionSettings(new PromptExecutionSettings
+        {
+            ModelId = "GigaChat-Max",
+            ExtensionData = new Dictionary<string, object>
+            {
+                ["temperature"] = 0.1,
+                ["max_tokens"] = 64,
+                ["max_tool_calls"] = 3,
+                ["flags"] = new[] { "debug" },
+                ["custom_field"] = "custom-value"
+            }
+        });
+
+        Assert.Equal("GigaChat-Max", settings.ModelId);
+        Assert.Equal(0.1, settings.Temperature);
+        Assert.Equal(64, settings.MaxTokens);
+        Assert.Equal(3, settings.MaxToolCalls);
+        Assert.Equal("debug", Assert.Single(settings.Flags!));
+        Assert.Equal("custom-value", settings.AdditionalFields!["custom_field"]);
+    }
+
+    private sealed class WeatherPlugin
+    {
+        [KernelFunction("get_weather")]
+        [Description("Gets current weather for a city.")]
+        public string GetWeather([Description("City name.")] string city) => $"{city} is 22 C";
+    }
+
+    private sealed record KernelRegistrationConfig(string ModelId, string Endpoint);
+}

--- a/tests/GigaChat.Net.Tests/TargetFrameworkCompatibilityTests.cs
+++ b/tests/GigaChat.Net.Tests/TargetFrameworkCompatibilityTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.Versioning;
 using GigaChat.Net.AspNetCore;
+using GigaChat.Net.SemanticKernel;
 
 namespace GigaChat.Net.Tests;
 
@@ -14,6 +15,7 @@ public class TargetFrameworkCompatibilityTests
         Assert.Equal(expectedFramework, GetTargetFramework(typeof(TargetFrameworkCompatibilityTests).Assembly));
         Assert.Equal(expectedFramework, GetTargetFramework(typeof(Settings).Assembly));
         Assert.Equal(expectedFramework, GetTargetFramework(typeof(GigaChatOptions).Assembly));
+        Assert.Equal(expectedFramework, GetTargetFramework(typeof(GigaChatChatCompletionService).Assembly));
     }
 
     private static string GetExpectedTargetFramework()

--- a/tests/GigaChat.Net.Tests/ToolSafetyTests.cs
+++ b/tests/GigaChat.Net.Tests/ToolSafetyTests.cs
@@ -1,0 +1,211 @@
+using System.ComponentModel;
+using System.Text.Json;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class ToolSafetyTests
+{
+    private static readonly string ToolCallJson = """
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_throws", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """;
+
+    [Fact]
+    public async Task ToolError_ReturnObservation_ContinuesLoopWithErrorAsResult()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(ToolCallJson);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "I got an error" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new ThrowingPlugin(), "stub");
+
+        var response = await service.GetChatMessageContentsAsync(
+            [new ChatMessageContent(AuthorRole.User, "try throwing")],
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                ToolSafety = new GigaChatToolSafetyOptions
+                {
+                    ErrorBehavior = GigaChatToolErrorBehavior.ReturnObservation
+                }
+            },
+            kernel);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("I got an error", Assert.Single(response).Content);
+
+        using var secondBody = JsonDocument.Parse(handler.Requests[1].Body!);
+        var messages = secondBody.RootElement.GetProperty("messages");
+        var functionMsg = messages[2];
+        Assert.Equal("function", functionMsg.GetProperty("role").GetString());
+        Assert.Contains("InvalidOperationException", functionMsg.GetProperty("content").GetString());
+    }
+
+    [Fact]
+    public async Task ToolError_FailFast_ThrowsImmediately()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(ToolCallJson);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new ThrowingPlugin(), "stub");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.GetChatMessageContentsAsync(
+                [new ChatMessageContent(AuthorRole.User, "try throwing")],
+                new GigaChatPromptExecutionSettings
+                {
+                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                    ToolSafety = new GigaChatToolSafetyOptions
+                    {
+                        ErrorBehavior = GigaChatToolErrorBehavior.FailFast
+                    }
+                },
+                kernel));
+    }
+
+    [Fact]
+    public async Task ToolOutput_TruncatedToMaxOutputLength()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_long_output", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson(TestData.Fixture("chat_completion.json"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new LongOutputPlugin(), "stub");
+
+        await service.GetChatMessageContentsAsync(
+            [new ChatMessageContent(AuthorRole.User, "long output")],
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                ToolSafety = new GigaChatToolSafetyOptions { MaxOutputLength = 10 }
+            },
+            kernel);
+
+        using var secondBody = JsonDocument.Parse(handler.Requests[1].Body!);
+        var content = secondBody.RootElement.GetProperty("messages")[2].GetProperty("content").GetString();
+        Assert.True(content!.Length <= 10 + "[truncated]".Length);
+        Assert.EndsWith("[truncated]", content);
+    }
+
+    [Fact]
+    public async Task AllowedPlugins_RejectsCallToBlockedPlugin()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson(ToolCallJson.Replace("stub_throws", "stub_do_work"));
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new ThrowingPlugin(), "stub");
+
+        var ex = await Assert.ThrowsAsync<GigaChatException>(
+            () => service.GetChatMessageContentsAsync(
+                [new ChatMessageContent(AuthorRole.User, "blocked")],
+                new GigaChatPromptExecutionSettings
+                {
+                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                    ToolSafety = new GigaChatToolSafetyOptions
+                    {
+                        AllowedPlugins = new HashSet<string>(StringComparer.Ordinal) { "other_plugin" }
+                    }
+                },
+                kernel));
+
+        Assert.Contains("allowed-plugins", ex.Message);
+    }
+
+    [Fact]
+    public async Task AllowedPlugins_NullPluginName_IsBlocked()
+    {
+        // Verifies M3: a KernelFunction whose PluginName is null must NOT bypass AllowedPlugins.
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_do_work", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+
+        // Register function without a plugin name so PluginName is null.
+        var kernel = Kernel.CreateBuilder().Build();
+        var fn = kernel.CreateFunctionFromMethod(() => "done", "do_work");
+        kernel.Plugins.Add(KernelPluginFactory.CreateFromFunctions("stub", [fn]));
+
+        // The plugin is named "stub" here (AddFromFunctions gives it a name),
+        // but AllowedPlugins only allows "other" — so it should be blocked.
+        var ex = await Assert.ThrowsAsync<GigaChatException>(
+            () => service.GetChatMessageContentsAsync(
+                [new ChatMessageContent(AuthorRole.User, "go")],
+                new GigaChatPromptExecutionSettings
+                {
+                    FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                    ToolSafety = new GigaChatToolSafetyOptions
+                    {
+                        AllowedPlugins = new HashSet<string>(StringComparer.Ordinal) { "other" }
+                    }
+                },
+                kernel));
+
+        Assert.Contains("allowed-plugins", ex.Message);
+    }
+
+    private sealed class ThrowingPlugin
+    {
+        [KernelFunction("throws")]
+        [Description("Throws on purpose.")]
+        public string Throws() => throw new InvalidOperationException("tool failed");
+
+        [KernelFunction("do_work")]
+        [Description("Does work.")]
+        public string DoWork() => "done";
+    }
+
+    private sealed class LongOutputPlugin
+    {
+        [KernelFunction("long_output")]
+        [Description("Returns a very long string.")]
+        public string LongOutput() => new string('x', 1000);
+    }
+}


### PR DESCRIPTION
## Summary

Stable release 1.1.0 — introduces `GigaChat.Net.SemanticKernel` to the production channel alongside bumping all package versions.

**New in this release:**
- `GigaChatReActAgent` — fluent builder for Reason+Act tool loops
- `GigaChatAgentStep` hierarchy + per-step latency tracing via `RunWithStepsAsync`
- `GigaChatToolSafetyOptions` — `ErrorBehavior`, `MaxOutputLength`, `AllowedPlugins`
- `GigaChatReActInstructions` — 5 ready-made system-prompt templates
- `InMemoryGigaChatAgentThreadStore` — multi-turn thread persistence
- Bug fixes: MaxToolCalls off-by-one (B1), thread history preserves intermediate tool messages (B2), AllowedPlugins null-name bypass (M3), guard on empty Choices (M2)

**Version bumps:** `GigaChat.Net` and `GigaChat.Net.AspNetCore` 1.0.2 → 1.1.0, `GigaChat.Net.SemanticKernel` first stable release at 1.1.0.

## Merge procedure

After CI passes, merge this PR then create GitHub Release `v1.1.0` — the `publish-release` workflow fires automatically and pushes all three packages to NuGet and GitHub Packages.

Closes #39