### PR TITLE
[GN-51] feat: add interrupt model to agent pipeline

### DIFF
--- a/src/GigaChat.Net.SemanticKernel/GigaChatAgentRunResult.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatAgentRunResult.cs
@@ -17,4 +17,16 @@ public sealed class GigaChatAgentRunResult
 
     /// <summary>Ordered list of steps executed during the run.</summary>
     public IReadOnlyList<GigaChatAgentStep> Steps { get; init; } = [];
+
+    /// <summary>
+    /// Whether the run completed normally or was interrupted before a tool call.
+    /// Defaults to <see cref="GigaChatRunStatus.Completed"/>.
+    /// </summary>
+    public GigaChatRunStatus Status { get; init; } = GigaChatRunStatus.Completed;
+
+    /// <summary>
+    /// The tool call that triggered the interrupt. <see langword="null"/> when
+    /// <see cref="Status"/> is <see cref="GigaChatRunStatus.Completed"/>.
+    /// </summary>
+    public GigaChatPendingToolCall? PendingToolCall { get; init; }
 }

--- a/src/GigaChat.Net.SemanticKernel/GigaChatAgentThread.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatAgentThread.cs
@@ -13,4 +13,10 @@ public sealed class GigaChatAgentThread
 
     /// <summary>All steps emitted across all runs in this thread.</summary>
     public IReadOnlyList<GigaChatAgentStep> Steps { get; init; } = [];
+
+    /// <summary>
+    /// The pending tool call from the last interrupted run, or <see langword="null"/>
+    /// when the thread is in a normal (non-interrupted) state.
+    /// </summary>
+    public GigaChatPendingToolCall? PendingToolCall { get; init; }
 }

--- a/src/GigaChat.Net.SemanticKernel/GigaChatPendingToolCall.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatPendingToolCall.cs
@@ -1,0 +1,17 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>
+/// Describes the tool call that was about to be made when an agent run was interrupted.
+/// </summary>
+public sealed class GigaChatPendingToolCall
+{
+    /// <summary>Name of the Semantic Kernel plugin that owns the function.</summary>
+    public string PluginName { get; init; } = string.Empty;
+
+    /// <summary>Name of the function within the plugin.</summary>
+    public string FunctionName { get; init; } = string.Empty;
+
+    /// <summary>Arguments that would have been passed to the function.</summary>
+    public IReadOnlyDictionary<string, object?> Arguments { get; init; } =
+        new Dictionary<string, object?>();
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatRunStatus.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatRunStatus.cs
@@ -1,0 +1,15 @@
+namespace GigaChat.Net.SemanticKernel;
+
+/// <summary>Indicates how an agent run ended.</summary>
+public enum GigaChatRunStatus
+{
+    /// <summary>The run completed normally and produced a final reply.</summary>
+    Completed = 0,
+
+    /// <summary>
+    /// The run was paused before invoking a tool whose plugin name appears in
+    /// <see cref="GigaChatToolSafetyOptions.InterruptBefore"/>. No tool was called.
+    /// Resume via <c>GigaChatReActAgent.ResumeAsync</c>.
+    /// </summary>
+    Interrupted = 1
+}

--- a/src/GigaChat.Net.SemanticKernel/GigaChatToolSafetyOptions.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatToolSafetyOptions.cs
@@ -22,4 +22,13 @@ public sealed class GigaChatToolSafetyOptions
     /// plugin name is treated as not allowed when this set is non-null.
     /// </summary>
     public IReadOnlySet<string>? AllowedPlugins { get; init; }
+
+    /// <summary>
+    /// Plugin names to interrupt before calling. When the tool loop resolves a function
+    /// whose plugin name appears in this set, the run pauses and returns
+    /// <see cref="GigaChatRunStatus.Interrupted"/> before the function is invoked.
+    /// Resume the run via <c>GigaChatReActAgent.ResumeAsync</c>.
+    /// Null disables interrupt (default behaviour).
+    /// </summary>
+    public IReadOnlySet<string>? InterruptBefore { get; init; }
 }

--- a/tests/GigaChat.Net.Tests/InterruptModelTests.cs
+++ b/tests/GigaChat.Net.Tests/InterruptModelTests.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class InterruptModelTests
+{
+    [Fact]
+    public void AgentRunResult_DefaultStatus_IsCompleted()
+    {
+        var result = new GigaChatAgentRunResult();
+
+        Assert.Equal(GigaChatRunStatus.Completed, result.Status);
+        Assert.Null(result.PendingToolCall);
+    }
+
+    [Fact]
+    public void AgentRunResult_Interrupted_CarriesPendingToolCall()
+    {
+        var pending = new GigaChatPendingToolCall
+        {
+            PluginName = "MyPlugin",
+            FunctionName = "DoWork",
+            Arguments = new Dictionary<string, object?> { ["x"] = 42 }
+        };
+        var result = new GigaChatAgentRunResult
+        {
+            Status = GigaChatRunStatus.Interrupted,
+            PendingToolCall = pending
+        };
+
+        Assert.Equal(GigaChatRunStatus.Interrupted, result.Status);
+        Assert.NotNull(result.PendingToolCall);
+        Assert.Equal("MyPlugin", result.PendingToolCall.PluginName);
+        Assert.Equal("DoWork", result.PendingToolCall.FunctionName);
+        Assert.Equal(42, result.PendingToolCall.Arguments["x"]);
+    }
+
+    [Fact]
+    public void AgentRunResult_Completed_SerializesWithDefaultStatus()
+    {
+        var result = new GigaChatAgentRunResult
+        {
+            Messages = [new ChatMessageContent(AuthorRole.Assistant, "hello")],
+            FullRunMessages = [new ChatMessageContent(AuthorRole.Assistant, "hello")],
+            Steps = []
+        };
+
+        // Status defaults to Completed (0) — round-trip should preserve that
+        Assert.Equal(GigaChatRunStatus.Completed, result.Status);
+        Assert.Null(result.PendingToolCall);
+    }
+
+    [Fact]
+    public void AgentThread_DefaultPendingToolCall_IsNull()
+    {
+        var thread = new GigaChatAgentThread { ThreadId = "t1" };
+
+        Assert.Null(thread.PendingToolCall);
+    }
+
+    [Fact]
+    public void AgentThread_WithPendingToolCall_RoundTrips()
+    {
+        var pending = new GigaChatPendingToolCall
+        {
+            PluginName = "P",
+            FunctionName = "F",
+            Arguments = new Dictionary<string, object?>()
+        };
+        var thread = new GigaChatAgentThread
+        {
+            ThreadId = "t2",
+            PendingToolCall = pending
+        };
+
+        Assert.Equal("P", thread.PendingToolCall!.PluginName);
+        Assert.Equal("F", thread.PendingToolCall.FunctionName);
+    }
+
+    [Fact]
+    public void ToolSafetyOptions_InterruptBefore_DefaultIsNull()
+    {
+        var options = new GigaChatToolSafetyOptions();
+
+        Assert.Null(options.InterruptBefore);
+    }
+
+    [Fact]
+    public void ToolSafetyOptions_InterruptBefore_HoldsPluginNames()
+    {
+        var options = new GigaChatToolSafetyOptions
+        {
+            InterruptBefore = new HashSet<string> { "DangerousPlugin", "AnotherPlugin" }
+        };
+
+        Assert.Contains("DangerousPlugin", options.InterruptBefore);
+        Assert.Contains("AnotherPlugin", options.InterruptBefore);
+        Assert.Equal(2, options.InterruptBefore.Count);
+    }
+
+    [Fact]
+    public void PendingToolCall_EmptyArgumentsByDefault()
+    {
+        var pending = new GigaChatPendingToolCall();
+
+        Assert.Empty(pending.PluginName);
+        Assert.Empty(pending.FunctionName);
+        Assert.Empty(pending.Arguments);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `GigaChatRunStatus` enum (`Completed` / `Interrupted`)
- Add `GigaChatPendingToolCall` (PluginName, FunctionName, Arguments)
- Extend `GigaChatAgentRunResult` with `Status` and `PendingToolCall`
- Extend `GigaChatAgentThread` with `PendingToolCall`
- Extend `GigaChatToolSafetyOptions` with `InterruptBefore` set

All new properties are init-only, backward-compatible (default `Status=Completed`, `PendingToolCall=null`).

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 131/131 passed across net6–net10
- [x] `InterruptModelTests` — 8 new tests covering all new types and defaults

Closes #51