### PR TITLE
[GN-52] feat: implement interrupt-before in GigaChatChatCompletionService tool loop

### DIFF
--- a/src/GigaChat.Net.SemanticKernel/GigaChatChatCompletionService.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatChatCompletionService.cs
@@ -166,25 +166,44 @@ public sealed class GigaChatChatCompletionService : IChatCompletionService
         var settings = GigaChatPromptExecutionSettings.FromExecutionSettings(executionSettings);
         var steps = new List<GigaChatAgentStep>();
         var allGenerated = new List<ChatMessageContent>();
-        var finalMessages = await RunToolLoopAsync(chatHistory, settings, kernel, steps, allGenerated, cancellationToken);
+        var loopResult = await RunToolLoopAsync(chatHistory, settings, kernel, steps, allGenerated, cancellationToken);
+
+        if (loopResult.Pending is { } pending)
+        {
+            return new GigaChatAgentRunResult
+            {
+                Status = GigaChatRunStatus.Interrupted,
+                Messages = [],
+                FullRunMessages = allGenerated,
+                Steps = steps,
+                PendingToolCall = pending
+            };
+        }
+
         return new GigaChatAgentRunResult
         {
-            Messages = finalMessages,
+            Messages = loopResult.FinalMessages!,
             FullRunMessages = allGenerated,
             Steps = steps
         };
     }
 
-    private Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsWithToolsAsync(
+    private async Task<IReadOnlyList<ChatMessageContent>> GetChatMessageContentsWithToolsAsync(
         ChatHistory chatHistory,
         GigaChatPromptExecutionSettings settings,
         Kernel? kernel,
         CancellationToken cancellationToken)
     {
-        return RunToolLoopAsync(chatHistory, settings, kernel, steps: null, allGenerated: null, cancellationToken);
+        var result = await RunToolLoopAsync(chatHistory, settings, kernel, steps: null, allGenerated: null, cancellationToken);
+        return result.FinalMessages ?? [];
     }
 
-    private async Task<IReadOnlyList<ChatMessageContent>> RunToolLoopAsync(
+    // Carries either normal completion (FinalMessages set) or an interrupted state (Pending set).
+    private readonly record struct ToolLoopResult(
+        IReadOnlyList<ChatMessageContent>? FinalMessages,
+        GigaChatPendingToolCall? Pending);
+
+    private async Task<ToolLoopResult> RunToolLoopAsync(
         ChatHistory chatHistory,
         GigaChatPromptExecutionSettings settings,
         Kernel? kernel,
@@ -228,7 +247,7 @@ public sealed class GigaChatChatCompletionService : IChatCompletionService
                     .Select(finalChoice => CreateChatMessageContent(finalChoice, completion, functionCalls, functionMap))
                     .ToArray();
                 allGenerated?.AddRange(finalMessages);
-                return finalMessages;
+                return new ToolLoopResult(finalMessages, null);
             }
 
             messages.Add(message);
@@ -261,6 +280,18 @@ public sealed class GigaChatChatCompletionService : IChatCompletionService
             {
                 throw new GigaChatException(
                     $"Plugin '{kernelFunction.Metadata.PluginName}' is not in the allowed-plugins list.");
+            }
+
+            if (safety?.InterruptBefore is { } interruptBefore
+                && kernelFunction.Metadata.PluginName is { } pluginName
+                && interruptBefore.Contains(pluginName))
+            {
+                return new ToolLoopResult(null, new GigaChatPendingToolCall
+                {
+                    PluginName = pluginName,
+                    FunctionName = kernelFunction.Name,
+                    Arguments = functionCall.Arguments ?? new Dictionary<string, object?>()
+                });
             }
 
             var toolSw = System.Diagnostics.Stopwatch.StartNew();

--- a/src/GigaChat.Net.SemanticKernel/GigaChatReActAgent.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatReActAgent.cs
@@ -80,7 +80,8 @@ public sealed class GigaChatReActAgent
         {
             ThreadId = threadId,
             History = updatedHistory,
-            Steps = updatedSteps
+            Steps = updatedSteps,
+            PendingToolCall = result.PendingToolCall
         }, cancellationToken);
 
         return result;

--- a/tests/GigaChat.Net.Tests/ToolSafetyTests.cs
+++ b/tests/GigaChat.Net.Tests/ToolSafetyTests.cs
@@ -191,6 +191,97 @@ public class ToolSafetyTests
         Assert.Contains("allowed-plugins", ex.Message);
     }
 
+    [Fact]
+    public async Task InterruptBefore_PausesRunBeforeToolInvocation()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_do_work", "arguments": { "x": 1 } } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new ThrowingPlugin(), "stub");
+
+        var result = await service.RunWithStepsAsync(
+            [new ChatMessageContent(AuthorRole.User, "do something")],
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                ToolSafety = new GigaChatToolSafetyOptions
+                {
+                    InterruptBefore = new HashSet<string>(StringComparer.Ordinal) { "stub" }
+                }
+            },
+            kernel);
+
+        // Only one HTTP request — the tool was never invoked.
+        Assert.Single(handler.Requests);
+        Assert.Equal(GigaChatRunStatus.Interrupted, result.Status);
+        Assert.Empty(result.Messages);
+        Assert.NotNull(result.PendingToolCall);
+        Assert.Equal("stub", result.PendingToolCall.PluginName);
+        Assert.Equal("do_work", result.PendingToolCall.FunctionName);
+        // The function-call message appears in FullRunMessages so thread history is complete.
+        Assert.NotEmpty(result.FullRunMessages);
+    }
+
+    [Fact]
+    public async Task InterruptBefore_NonMatchingPlugin_ContinuesNormally()
+    {
+        var handler = new RecordingHandler();
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "",
+            "function_call": { "name": "stub_do_work", "arguments": {} } },
+            "index": 0, "finish_reason": "function_call" }],
+          "created": 1, "model": "GigaChat",
+          "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+          "object": "chat.completion"
+        }
+        """);
+        handler.QueueJson("""
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "done" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+        var service = new GigaChatChatCompletionService(client);
+        var kernel = Kernel.CreateBuilder().Build();
+        kernel.Plugins.AddFromObject(new ThrowingPlugin(), "stub");
+
+        var result = await service.RunWithStepsAsync(
+            [new ChatMessageContent(AuthorRole.User, "do something")],
+            new GigaChatPromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                ToolSafety = new GigaChatToolSafetyOptions
+                {
+                    InterruptBefore = new HashSet<string>(StringComparer.Ordinal) { "other_plugin" }
+                }
+            },
+            kernel);
+
+        // Two HTTP calls — tool ran normally.
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(GigaChatRunStatus.Completed, result.Status);
+        Assert.Null(result.PendingToolCall);
+        Assert.Equal("done", Assert.Single(result.Messages).Content);
+    }
+
     private sealed class ThrowingPlugin
     {
         [KernelFunction("throws")]


### PR DESCRIPTION
## Summary

- Introduce private `ToolLoopResult` record (FinalMessages / Pending) to carry interrupt signal out of `RunToolLoopAsync` without changing the public API
- Add `InterruptBefore` check in `RunToolLoopAsync` after `AllowedPlugins` guard — returns immediately with `Pending` set, tool is **not** invoked
- `RunWithStepsAsync` maps `Pending != null` → `GigaChatAgentRunResult { Status=Interrupted, PendingToolCall=... }`
- `GigaChatReActAgent.InvokeAsync(threadId)` persists `PendingToolCall` to thread store on interrupted runs

Without `InterruptBefore` (or no match) all existing behaviour is unchanged.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 133/133 passed across net6–net10
- [x] `InterruptBefore_PausesRunBeforeToolInvocation` — 1 HTTP call, Status=Interrupted, PendingToolCall filled, FullRunMessages non-empty
- [x] `InterruptBefore_NonMatchingPlugin_ContinuesNormally` — 2 HTTP calls, Status=Completed, PendingToolCall=null

Closes #52