### PR TITLE
[GN-53] feat: add ResumeAsync to GigaChatReActAgent

### DIFF
--- a/src/GigaChat.Net.SemanticKernel/GigaChatReActAgent.cs
+++ b/src/GigaChat.Net.SemanticKernel/GigaChatReActAgent.cs
@@ -87,6 +87,70 @@ public sealed class GigaChatReActAgent
         return result;
     }
 
+    /// <summary>
+    /// Resumes an interrupted thread. If <paramref name="humanInput"/> is provided it is injected
+    /// as the tool-result observation for the pending tool call — the tool is NOT invoked.
+    /// If <paramref name="humanInput"/> is <see langword="null"/>, the pending tool is executed
+    /// normally via the Kernel and the run continues from the result.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no thread store is configured, the thread is not found, or the thread is not
+    /// in an interrupted state.
+    /// </exception>
+    public async Task<GigaChatAgentRunResult> ResumeAsync(
+        string threadId,
+        string? humanInput = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(threadId))
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(threadId));
+
+        if (_threadStore is null)
+            throw new InvalidOperationException(
+                "Thread store is not configured. Call UseThreadStore() on the builder.");
+
+        var thread = await _threadStore.LoadAsync(threadId, cancellationToken)
+            ?? throw new InvalidOperationException($"Thread '{threadId}' not found.");
+
+        if (thread.PendingToolCall is null)
+            throw new InvalidOperationException(
+                $"Thread '{threadId}' is not in an interrupted state.");
+
+        var history = thread.History.ToList();
+        var pending = thread.PendingToolCall;
+
+        if (humanInput is not null)
+        {
+            // Human override: inject as observation, skip actual tool invocation.
+            history.Add(new ChatMessageContent(AuthorRole.Tool, humanInput));
+        }
+        else
+        {
+            // Normal resume: invoke the pending function directly via the Kernel.
+            var fn = Kernel.Plugins.GetFunction(pending.PluginName, pending.FunctionName);
+            var args = new KernelArguments();
+            foreach (var (k, v) in pending.Arguments)
+                args[k] = v;
+            var fnResult = await fn.InvokeAsync(Kernel, args, cancellationToken);
+            history.Add(new ChatMessageContent(AuthorRole.Tool, fnResult.ToString() ?? string.Empty));
+        }
+
+        var result = await InvokeAsync((IReadOnlyList<ChatMessageContent>)history, cancellationToken);
+
+        var updatedSteps = thread.Steps.Concat(result.Steps).ToList();
+        await _threadStore.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = threadId,
+            History = history.Concat(result.FullRunMessages).ToList(),
+            Steps = updatedSteps,
+            PendingToolCall = result.Status == GigaChatRunStatus.Interrupted
+                ? result.PendingToolCall
+                : null
+        }, cancellationToken);
+
+        return result;
+    }
+
     /// <summary>Runs the agent on a pre-built chat history and returns the result with step trace.</summary>
     public Task<GigaChatAgentRunResult> InvokeAsync(
         IReadOnlyList<ChatMessageContent> history,

--- a/tests/GigaChat.Net.Tests/ResumeAsyncTests.cs
+++ b/tests/GigaChat.Net.Tests/ResumeAsyncTests.cs
@@ -1,0 +1,166 @@
+using System.ComponentModel;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class ResumeAsyncTests
+{
+    private static readonly string FinalReplyJson = """
+        {
+          "choices": [{ "message": { "role": "assistant", "content": "all done" },
+            "index": 0, "finish_reason": "stop" }],
+          "created": 2, "model": "GigaChat",
+          "usage": { "prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4 },
+          "object": "chat.completion"
+        }
+        """;
+
+    [Fact]
+    public async Task ResumeAsync_WithHumanInput_InjectsObservationAndContinues()
+    {
+        // The interrupted thread has a pending tool call for "stub.do_work".
+        // Resuming with human input should inject the input as a tool result
+        // and continue without invoking the actual function.
+        var store = new InMemoryGigaChatAgentThreadStore();
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t1",
+            History = [
+                new ChatMessageContent(AuthorRole.User, "go"),
+                new ChatMessageContent(AuthorRole.Assistant, string.Empty) // function_call msg
+            ],
+            PendingToolCall = new GigaChatPendingToolCall
+            {
+                PluginName = "stub",
+                FunctionName = "do_work",
+                Arguments = new Dictionary<string, object?>()
+            }
+        });
+
+        var handler = new RecordingHandler();
+        handler.QueueJson(FinalReplyJson);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+
+        var agent = GigaChatReActAgent.Create(b =>
+        {
+            b.UseClient(client);
+            b.UseThreadStore(store);
+            b.AddPlugin(new StubPlugin(), "stub");
+        });
+
+        var result = await agent.ResumeAsync("t1", humanInput: "human override");
+
+        Assert.Equal(GigaChatRunStatus.Completed, result.Status);
+        Assert.Equal("all done", Assert.Single(result.Messages).Content);
+        // Only one API call (human input injected — no tool invocation)
+        Assert.Single(handler.Requests);
+        // Thread PendingToolCall should be cleared
+        var saved = await store.LoadAsync("t1");
+        Assert.Null(saved!.PendingToolCall);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_WithNullInput_InvokesToolAndContinues()
+    {
+        // Resume with null humanInput — the tool should be invoked normally.
+        var store = new InMemoryGigaChatAgentThreadStore();
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t2",
+            History = [
+                new ChatMessageContent(AuthorRole.User, "go"),
+                new ChatMessageContent(AuthorRole.Assistant, string.Empty)
+            ],
+            PendingToolCall = new GigaChatPendingToolCall
+            {
+                PluginName = "stub",
+                FunctionName = "do_work",
+                Arguments = new Dictionary<string, object?>()
+            }
+        });
+
+        var handler = new RecordingHandler();
+        handler.QueueJson(FinalReplyJson);
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl }, handler);
+
+        var agent = GigaChatReActAgent.Create(b =>
+        {
+            b.UseClient(client);
+            b.UseThreadStore(store);
+            b.AddPlugin(new StubPlugin(), "stub");
+        });
+
+        var result = await agent.ResumeAsync("t2", humanInput: null);
+
+        Assert.Equal(GigaChatRunStatus.Completed, result.Status);
+        Assert.Equal("all done", Assert.Single(result.Messages).Content);
+        // Thread cleared
+        var saved = await store.LoadAsync("t2");
+        Assert.Null(saved!.PendingToolCall);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_ThreadNotFound_Throws()
+    {
+        var store = new InMemoryGigaChatAgentThreadStore();
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl });
+
+        var agent = GigaChatReActAgent.Create(b =>
+        {
+            b.UseClient(client);
+            b.UseThreadStore(store);
+        });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ResumeAsync("missing"));
+        Assert.Contains("missing", ex.Message);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_ThreadNotInterrupted_Throws()
+    {
+        var store = new InMemoryGigaChatAgentThreadStore();
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t3",
+            History = [new ChatMessageContent(AuthorRole.User, "hi")]
+        });
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl });
+
+        var agent = GigaChatReActAgent.Create(b =>
+        {
+            b.UseClient(client);
+            b.UseThreadStore(store);
+        });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ResumeAsync("t3"));
+        Assert.Contains("interrupted", ex.Message);
+    }
+
+    [Fact]
+    public async Task ResumeAsync_WithoutThreadStore_Throws()
+    {
+        using var client = new GigaChatClient(
+            new Settings { AccessToken = "token", BaseUrl = TestData.BaseUrl });
+
+        var agent = GigaChatReActAgent.Create(b => b.UseClient(client));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => agent.ResumeAsync("t1"));
+        Assert.Contains("Thread store", ex.Message);
+    }
+
+    private sealed class StubPlugin
+    {
+        [KernelFunction("do_work")]
+        [Description("Does work.")]
+        public string DoWork() => "tool result";
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ResumeAsync(threadId, humanInput?, ct)` to `GigaChatReActAgent`
- `humanInput != null` → inject as `AuthorRole.Tool` observation, skip tool invocation
- `humanInput == null` → invoke the pending function via `Kernel.Plugins.GetFunction(...)`, inject result as tool observation, then continue the run
- `PendingToolCall` is cleared on normal completion, preserved if the resumed run is also interrupted (nested interrupt support)
- Guard: throws `InvalidOperationException` if no thread store, thread not found, or thread not interrupted

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 138/138 passed across net6–net10
- [x] `ResumeAsync_WithHumanInput_InjectsObservationAndContinues` — 1 API call, PendingToolCall cleared
- [x] `ResumeAsync_WithNullInput_InvokesToolAndContinues` — tool invoked, PendingToolCall cleared
- [x] `ResumeAsync_ThreadNotFound_Throws`
- [x] `ResumeAsync_ThreadNotInterrupted_Throws`
- [x] `ResumeAsync_WithoutThreadStore_Throws`

Closes #53