### PR TITLE
[GN-54] feat: add GigaChat.Net.EFCore package scaffold

### DIFF
--- a/GigaChat.Net.slnx
+++ b/GigaChat.Net.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/GigaChat.Net.AspNetCore/GigaChat.Net.AspNetCore.csproj" />
     <Project Path="src/GigaChat.Net/GigaChat.Net.csproj" />
     <Project Path="src/GigaChat.Net.SemanticKernel/GigaChat.Net.SemanticKernel.csproj" />
+    <Project Path="src/GigaChat.Net.EFCore/GigaChat.Net.EFCore.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj" />

--- a/src/GigaChat.Net.EFCore/GigaChat.Net.EFCore.csproj
+++ b/src/GigaChat.Net.EFCore/GigaChat.Net.EFCore.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- NuGet Package Metadata -->
+    <PackageId>GigaChat.Net.EFCore</PackageId>
+    <Version>1.1.0</Version>
+    <Authors>GigaChat.Net Contributors</Authors>
+    <Description>Entity Framework Core thread store for GigaChat.Net agents — persistent interrupt/resume checkpointing for GigaChatReActAgent.</Description>
+    <PackageTags>gigachat;semantic-kernel;efcore;entity-framework;agents;checkpointer;ai;llm;sber</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <RepositoryUrl>https://github.com/h0tnanny/GigaChat-Net</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/h0tnanny/GigaChat-Net</PackageProjectUrl>
+    <PackageReleaseNotes>Initial release. EF Core-backed IGigaChatAgentThreadStore with optimistic concurrency and interrupt/resume support.</PackageReleaseNotes>
+
+    <!-- Symbol and Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Documentation -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Provider-agnostic EF Core. Users add their own provider (Npgsql, SQLite, SqlServer). -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <ProjectReference Include="..\GigaChat.Net.SemanticKernel\GigaChat.Net.SemanticKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GigaChat.Net.EFCore/GigaChatDbContext.cs
+++ b/src/GigaChat.Net.EFCore/GigaChatDbContext.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace GigaChat.Net.EFCore;
+
+/// <summary>
+/// EF Core DbContext for persisting GigaChat agent threads.
+/// Derive from this class in your application to add it to your own DbContext,
+/// or use it directly with a provider-specific <see cref="DbContextOptions"/>.
+/// </summary>
+public class GigaChatDbContext : DbContext
+{
+    /// <inheritdoc />
+    public GigaChatDbContext(DbContextOptions<GigaChatDbContext> options) : base(options) { }
+
+    /// <summary>Agent thread records.</summary>
+    public DbSet<GigaChatThreadRecord> GigaChatThreads => Set<GigaChatThreadRecord>();
+
+    /// <inheritdoc />
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<GigaChatThreadRecord>(entity =>
+        {
+            entity.HasKey(x => x.ThreadId);
+            entity.Property(x => x.ThreadId).HasMaxLength(256);
+            entity.Property(x => x.HistoryJson).IsRequired();
+            entity.Property(x => x.StepsJson).IsRequired();
+            entity.Property(x => x.RowVersion).IsRowVersion();
+        });
+    }
+}

--- a/src/GigaChat.Net.EFCore/GigaChatMessageDto.cs
+++ b/src/GigaChat.Net.EFCore/GigaChatMessageDto.cs
@@ -1,0 +1,126 @@
+using GigaChat.Net.SemanticKernel;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.EFCore;
+
+/// <summary>Serialization DTO for <see cref="ChatMessageContent"/> stored in <see cref="GigaChatThreadRecord"/>.</summary>
+public sealed class GigaChatMessageDto
+{
+    /// <summary>Author role label (e.g. "user", "assistant", "system", "tool").</summary>
+    public string Role { get; init; } = string.Empty;
+
+    /// <summary>Text content of the message.</summary>
+    public string Content { get; init; } = string.Empty;
+
+    /// <summary>Creates a DTO from a <see cref="ChatMessageContent"/>.</summary>
+    public static GigaChatMessageDto FromMessage(ChatMessageContent msg) =>
+        new() { Role = msg.Role.Label, Content = msg.Content ?? string.Empty };
+
+    /// <summary>Reconstructs a <see cref="ChatMessageContent"/> from this DTO.</summary>
+    public ChatMessageContent ToMessage() =>
+        new(new AuthorRole(Role), Content);
+}
+
+/// <summary>Serialization DTO for <see cref="GigaChatPendingToolCall"/>.</summary>
+public sealed class GigaChatPendingToolCallDto
+{
+    public string PluginName { get; init; } = string.Empty;
+    public string FunctionName { get; init; } = string.Empty;
+    public Dictionary<string, object?> Arguments { get; init; } = [];
+
+    public static GigaChatPendingToolCallDto From(GigaChatPendingToolCall pending) =>
+        new()
+        {
+            PluginName = pending.PluginName,
+            FunctionName = pending.FunctionName,
+            Arguments = new Dictionary<string, object?>(pending.Arguments)
+        };
+
+    public GigaChatPendingToolCall ToModel() =>
+        new()
+        {
+            PluginName = PluginName,
+            FunctionName = FunctionName,
+            Arguments = new Dictionary<string, object?>(Arguments)
+        };
+}
+
+/// <summary>Serialization DTO for a single <see cref="GigaChatAgentStep"/> stored in <see cref="GigaChatThreadRecord"/>.</summary>
+public sealed class GigaChatAgentStepDto
+{
+    /// <summary>Discriminator: "assistant", "tool_call", or "tool_result".</summary>
+    public string Kind { get; init; } = string.Empty;
+
+    public int RequestIndex { get; init; }
+    public long LatencyMs { get; init; }
+
+    // GigaChatAssistantMessageStep fields
+    public string? Content { get; init; }
+
+    // GigaChatToolCallStep / GigaChatToolResultStep fields
+    public string? ToolName { get; init; }
+    public string? Result { get; init; }
+    public Dictionary<string, object?>? Arguments { get; init; }
+    public string? ExceptionType { get; init; }
+    public string? ExceptionMessage { get; init; }
+
+    public static GigaChatAgentStepDto From(GigaChatAgentStep step) => step switch
+    {
+        GigaChatAssistantMessageStep s => new GigaChatAgentStepDto
+        {
+            Kind = "assistant",
+            RequestIndex = s.RequestIndex,
+            LatencyMs = s.LatencyMs,
+            Content = s.Content
+        },
+        GigaChatToolCallStep s => new GigaChatAgentStepDto
+        {
+            Kind = "tool_call",
+            RequestIndex = s.RequestIndex,
+            LatencyMs = s.LatencyMs,
+            ToolName = s.ToolName,
+            Arguments = s.Arguments is not null
+                ? new Dictionary<string, object?>(s.Arguments)
+                : null
+        },
+        GigaChatToolResultStep s => new GigaChatAgentStepDto
+        {
+            Kind = "tool_result",
+            RequestIndex = s.RequestIndex,
+            LatencyMs = s.LatencyMs,
+            ToolName = s.ToolName,
+            Result = s.Result,
+            ExceptionType = s.Exception?.GetType().FullName,
+            ExceptionMessage = s.Exception?.Message
+        },
+        _ => new GigaChatAgentStepDto { Kind = "unknown", RequestIndex = step.RequestIndex, LatencyMs = step.LatencyMs }
+    };
+
+    public GigaChatAgentStep ToModel() => Kind switch
+    {
+        "assistant" => new GigaChatAssistantMessageStep
+        {
+            RequestIndex = RequestIndex,
+            LatencyMs = LatencyMs,
+            Content = Content ?? string.Empty
+        },
+        "tool_call" => new GigaChatToolCallStep
+        {
+            RequestIndex = RequestIndex,
+            LatencyMs = LatencyMs,
+            ToolName = ToolName ?? string.Empty,
+            Arguments = Arguments is not null
+                ? new Dictionary<string, object?>(Arguments)
+                : null
+        },
+        "tool_result" => new GigaChatToolResultStep
+        {
+            RequestIndex = RequestIndex,
+            LatencyMs = LatencyMs,
+            ToolName = ToolName ?? string.Empty,
+            Result = Result ?? string.Empty
+        },
+        _ => throw new InvalidOperationException($"Unknown GigaChatAgentStep kind '{Kind}'. Possible data corruption or schema version mismatch.")
+    };
+}

--- a/src/GigaChat.Net.EFCore/GigaChatThreadRecord.cs
+++ b/src/GigaChat.Net.EFCore/GigaChatThreadRecord.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GigaChat.Net.EFCore;
+
+/// <summary>EF Core entity that persists a single agent conversation thread.</summary>
+public class GigaChatThreadRecord
+{
+    /// <summary>Stable thread identifier. Primary key.</summary>
+    public string ThreadId { get; set; } = string.Empty;
+
+    /// <summary>JSON-serialized <c>GigaChatMessageDto[]</c> representing the full message history.</summary>
+    public string HistoryJson { get; set; } = "[]";
+
+    /// <summary>JSON-serialized <c>GigaChatAgentStepDto[]</c> representing all run steps.</summary>
+    public string StepsJson { get; set; } = "[]";
+
+    /// <summary>
+    /// JSON-serialized <c>GigaChatPendingToolCallDto</c>, or <see langword="null"/> when the
+    /// thread is not in an interrupted state.
+    /// </summary>
+    public string? PendingToolCallJson { get; set; }
+
+    /// <summary>UTC timestamp when the record was first created.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>UTC timestamp of the last update.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>Optimistic concurrency token — set by the database on INSERT/UPDATE.</summary>
+    [Timestamp]
+    public byte[]? RowVersion { get; set; }
+}


### PR DESCRIPTION
## Summary

New provider-agnostic EF Core package for persisting GigaChat agent threads (net8–net10).

- `GigaChatDbContext` — base DbContext with `GigaChatThreads` DbSet; uses `DbContextOptions<GigaChatDbContext>` for correct multi-context DI
- `GigaChatThreadRecord` — EF entity with `RowVersion` optimistic concurrency token (nullable — avoids INSERT exception)
- `GigaChatMessageDto` / `GigaChatPendingToolCallDto` / `GigaChatAgentStepDto` — round-trip serialization DTOs for all thread model types

No provider dependency — users add Npgsql / SQLite / SqlServer themselves.

## Code review fixes (from `/code-review` run)

- `RowVersion` changed to `byte[]?` (null default) — `= []` caused `DbUpdateConcurrencyException` on first INSERT
- `DbContextOptions` → `DbContextOptions<GigaChatDbContext>` — DI fails otherwise when multiple contexts are registered
- `GigaChatPendingToolCallDto.ToModel()` and `GigaChatAgentStepDto.ToModel()` now defensively copy `Arguments` dictionary — prevents shared mutable reference
- `GigaChatAgentStepDto.ToModel()` default arm throws `InvalidOperationException` — silent fallthrough to empty AssistantMessageStep was masking data corruption

## Test plan

- [x] `dotnet build` — 0 errors across net8/net9/net10
- [x] `dotnet test` — 138/138 passed

Closes #54