### PR TITLE
[GN-55] feat: EFCoreGigaChatAgentThreadStore with InMemory tests

### DIFF
--- a/src/GigaChat.Net.EFCore/EFCoreGigaChatAgentThreadStore.cs
+++ b/src/GigaChat.Net.EFCore/EFCoreGigaChatAgentThreadStore.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.EntityFrameworkCore;
+
+namespace GigaChat.Net.EFCore;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="IGigaChatAgentThreadStore"/>.
+/// Uses <see cref="IDbContextFactory{TContext}"/> for thread-safe, scoped DbContext access.
+/// </summary>
+/// <typeparam name="TContext">
+/// The application's DbContext type, which must derive from <see cref="GigaChatDbContext"/>.
+/// </typeparam>
+public sealed class EFCoreGigaChatAgentThreadStore<TContext> : IGigaChatAgentThreadStore
+    where TContext : GigaChatDbContext
+{
+    private readonly IDbContextFactory<TContext> _factory;
+
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="EFCoreGigaChatAgentThreadStore{TContext}"/>.
+    /// </summary>
+    public EFCoreGigaChatAgentThreadStore(IDbContextFactory<TContext> factory)
+        => _factory = factory;
+
+    /// <inheritdoc />
+    /// <exception cref="DbUpdateConcurrencyException">
+    /// Thrown when a concurrent save is detected via the RowVersion concurrency token.
+    /// </exception>
+    public async Task SaveAsync(GigaChatAgentThread thread, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken);
+        var existing = await db.GigaChatThreads
+            .FindAsync([thread.ThreadId], cancellationToken);
+
+        var now = DateTimeOffset.UtcNow;
+        var historyJson = Serialize(thread.History.Select(GigaChatMessageDto.FromMessage).ToArray());
+        var stepsJson = Serialize(thread.Steps.Select(GigaChatAgentStepDto.From).ToArray());
+        var pendingJson = thread.PendingToolCall is null
+            ? null
+            : Serialize(GigaChatPendingToolCallDto.From(thread.PendingToolCall));
+
+        if (existing is null)
+        {
+            db.GigaChatThreads.Add(new GigaChatThreadRecord
+            {
+                ThreadId = thread.ThreadId,
+                HistoryJson = historyJson,
+                StepsJson = stepsJson,
+                PendingToolCallJson = pendingJson,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        }
+        else
+        {
+            // Update only data fields — RowVersion is managed by the database
+            // and must not be overwritten here; EF Core uses it as the concurrency token.
+            existing.HistoryJson = historyJson;
+            existing.StepsJson = stepsJson;
+            existing.PendingToolCallJson = pendingJson;
+            existing.UpdatedAt = now;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<GigaChatAgentThread?> LoadAsync(
+        string threadId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken);
+        var record = await db.GigaChatThreads
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.ThreadId == threadId, cancellationToken);
+
+        if (record is null)
+            return null;
+
+        try
+        {
+            return new GigaChatAgentThread
+            {
+                ThreadId = record.ThreadId,
+                History = Deserialize<GigaChatMessageDto[]>(record.HistoryJson)
+                    .Select(d => d.ToMessage())
+                    .ToList(),
+                Steps = Deserialize<GigaChatAgentStepDto[]>(record.StepsJson)
+                    .Select(d => d.ToModel())
+                    .ToList(),
+                PendingToolCall = record.PendingToolCallJson is null
+                    ? null
+                    : Deserialize<GigaChatPendingToolCallDto>(record.PendingToolCallJson).ToModel()
+            };
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                $"Failed to deserialize thread '{record.ThreadId}' from storage. " +
+                "The data may be corrupt or written by an incompatible version.", ex);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(cancellationToken);
+        var existing = await db.GigaChatThreads.FindAsync([threadId], cancellationToken);
+        if (existing is not null)
+        {
+            db.GigaChatThreads.Remove(existing);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static string Serialize<T>(T value) =>
+        JsonSerializer.Serialize(value, JsonOptions);
+
+    private static T Deserialize<T>(string json) =>
+        JsonSerializer.Deserialize<T>(json, JsonOptions)
+        ?? throw new InvalidOperationException($"Failed to deserialize {typeof(T).Name} from JSON.");
+}

--- a/src/GigaChat.Net.EFCore/GigaChatMessageDto.cs
+++ b/src/GigaChat.Net.EFCore/GigaChatMessageDto.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using GigaChat.Net.SemanticKernel;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
@@ -42,7 +43,9 @@ public sealed class GigaChatPendingToolCallDto
         {
             PluginName = PluginName,
             FunctionName = FunctionName,
-            Arguments = new Dictionary<string, object?>(Arguments)
+            Arguments = Arguments is not null
+                ? GigaChatAgentStepDto.UnwrapJsonElements(Arguments)
+                : new Dictionary<string, object?>()
         };
 }
 
@@ -111,7 +114,7 @@ public sealed class GigaChatAgentStepDto
             LatencyMs = LatencyMs,
             ToolName = ToolName ?? string.Empty,
             Arguments = Arguments is not null
-                ? new Dictionary<string, object?>(Arguments)
+                ? UnwrapJsonElements(Arguments)
                 : null
         },
         "tool_result" => new GigaChatToolResultStep
@@ -122,5 +125,28 @@ public sealed class GigaChatAgentStepDto
             Result = Result ?? string.Empty
         },
         _ => throw new InvalidOperationException($"Unknown GigaChatAgentStep kind '{Kind}'. Possible data corruption or schema version mismatch.")
+    };
+
+    /// <summary>
+    /// Converts any <see cref="JsonElement"/> values in the dictionary to their CLR equivalents
+    /// so callers receive typed values rather than opaque JsonElement after JSON round-trip.
+    /// </summary>
+    internal static Dictionary<string, object?> UnwrapJsonElements(Dictionary<string, object?> source)
+    {
+        var result = new Dictionary<string, object?>(source.Count, StringComparer.Ordinal);
+        foreach (var (k, v) in source)
+            result[k] = v is JsonElement je ? UnwrapJsonElement(je) : v;
+        return result;
+    }
+
+    private static object? UnwrapJsonElement(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.String => element.GetString(),
+        JsonValueKind.Number when element.TryGetInt64(out var l) => l,
+        JsonValueKind.Number => element.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null => null,
+        _ => element
     };
 }

--- a/tests/GigaChat.Net.Tests/EFCoreThreadStoreTests.cs
+++ b/tests/GigaChat.Net.Tests/EFCoreThreadStoreTests.cs
@@ -1,0 +1,195 @@
+#if NET8_0_OR_GREATER
+
+using GigaChat.Net.EFCore;
+using GigaChat.Net.SemanticKernel;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace GigaChat.Net.Tests;
+
+public class EFCoreThreadStoreTests
+{
+    private static IDbContextFactory<GigaChatDbContext> CreateFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<GigaChatDbContext>(options =>
+            options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        return services.BuildServiceProvider()
+                       .GetRequiredService<IDbContextFactory<GigaChatDbContext>>();
+    }
+
+    [Fact]
+    public async Task SaveAndLoad_RoundTrips_MessageHistory()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        var thread = new GigaChatAgentThread
+        {
+            ThreadId = "t1",
+            History =
+            [
+                new(AuthorRole.System, "You are helpful"),
+                new(AuthorRole.User, "Hello"),
+                new(AuthorRole.Assistant, "Hi there")
+            ]
+        };
+
+        await store.SaveAsync(thread);
+        var loaded = await store.LoadAsync("t1");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("t1", loaded.ThreadId);
+        Assert.Equal(3, loaded.History.Count);
+        Assert.Equal("system", loaded.History[0].Role.Label);
+        Assert.Equal("You are helpful", loaded.History[0].Content);
+        Assert.Equal("Hello", loaded.History[1].Content);
+        Assert.Equal("Hi there", loaded.History[2].Content);
+    }
+
+    [Fact]
+    public async Task SaveAndLoad_RoundTrips_PendingToolCall()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        var pending = new GigaChatPendingToolCall
+        {
+            PluginName = "MyPlugin",
+            FunctionName = "DoSomething",
+            Arguments = new Dictionary<string, object?> { ["x"] = 42L }
+        };
+        var thread = new GigaChatAgentThread
+        {
+            ThreadId = "t2",
+            PendingToolCall = pending
+        };
+
+        await store.SaveAsync(thread);
+        var loaded = await store.LoadAsync("t2");
+
+        Assert.NotNull(loaded?.PendingToolCall);
+        Assert.Equal("MyPlugin", loaded.PendingToolCall.PluginName);
+        Assert.Equal("DoSomething", loaded.PendingToolCall.FunctionName);
+    }
+
+    [Fact]
+    public async Task SaveAndLoad_NoPendingToolCall_IsNull()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        await store.SaveAsync(new GigaChatAgentThread { ThreadId = "t3" });
+        var loaded = await store.LoadAsync("t3");
+
+        Assert.Null(loaded?.PendingToolCall);
+    }
+
+    [Fact]
+    public async Task Load_UnknownThread_ReturnsNull()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        var result = await store.LoadAsync("missing");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesThread()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t4",
+            History = [new(AuthorRole.User, "hello")]
+        });
+        await store.DeleteAsync("t4");
+        Assert.Null(await store.LoadAsync("t4"));
+    }
+
+    [Fact]
+    public async Task Delete_NonExistent_DoesNotThrow()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        await store.DeleteAsync("does-not-exist");
+    }
+
+    [Fact]
+    public async Task Save_Twice_UpdatesExistingRecord()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t5",
+            History = [new(AuthorRole.User, "first")]
+        });
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t5",
+            History = [new(AuthorRole.User, "first"), new(AuthorRole.Assistant, "second")]
+        });
+
+        var loaded = await store.LoadAsync("t5");
+        Assert.Equal(2, loaded!.History.Count);
+        Assert.Equal("second", loaded.History[1].Content);
+    }
+
+    [Fact]
+    public async Task Save_ClearsPendingToolCall_OnSecondSave()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t6",
+            PendingToolCall = new GigaChatPendingToolCall
+            {
+                PluginName = "P", FunctionName = "F",
+                Arguments = new Dictionary<string, object?>()
+            }
+        });
+
+        // Resume clears PendingToolCall
+        await store.SaveAsync(new GigaChatAgentThread
+        {
+            ThreadId = "t6",
+            History = [new(AuthorRole.Assistant, "done")],
+            PendingToolCall = null
+        });
+
+        var loaded = await store.LoadAsync("t6");
+        Assert.Null(loaded?.PendingToolCall);
+        Assert.Single(loaded!.History);
+    }
+
+    [Fact]
+    public async Task SaveAndLoad_RoundTrips_AgentSteps()
+    {
+        var store = new EFCoreGigaChatAgentThreadStore<GigaChatDbContext>(CreateFactory());
+        var steps = new List<GigaChatAgentStep>
+        {
+            new GigaChatToolCallStep
+            {
+                RequestIndex = 0, LatencyMs = 100,
+                ToolName = "my_tool",
+                Arguments = new Dictionary<string, object?> { ["key"] = "val" }
+            },
+            new GigaChatToolResultStep
+            {
+                RequestIndex = 0, LatencyMs = 50,
+                ToolName = "my_tool", Result = "tool output"
+            },
+            new GigaChatAssistantMessageStep
+            {
+                RequestIndex = 0, LatencyMs = 200,
+                Content = "final answer"
+            }
+        };
+
+        await store.SaveAsync(new GigaChatAgentThread { ThreadId = "t7", Steps = steps });
+        var loaded = await store.LoadAsync("t7");
+
+        Assert.Equal(3, loaded!.Steps.Count);
+        var call = Assert.IsType<GigaChatToolCallStep>(loaded.Steps[0]);
+        Assert.Equal("my_tool", call.ToolName);
+        var result = Assert.IsType<GigaChatToolResultStep>(loaded.Steps[1]);
+        Assert.Equal("tool output", result.Result);
+        var msg = Assert.IsType<GigaChatAssistantMessageStep>(loaded.Steps[2]);
+        Assert.Equal("final answer", msg.Content);
+    }
+}
+
+#endif

--- a/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
+++ b/tests/GigaChat.Net.Tests/GigaChat.Net.Tests.csproj
@@ -28,6 +28,12 @@
     <ProjectReference Include="..\..\src\GigaChat.Net.AspNetCore\GigaChat.Net.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\GigaChat.Net\GigaChat.Net.csproj" />
     <ProjectReference Include="..\..\src\GigaChat.Net.SemanticKernel\GigaChat.Net.SemanticKernel.csproj" />
+    <ProjectReference Include="..\..\src\GigaChat.Net.EFCore\GigaChat.Net.EFCore.csproj"
+                      Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- `EFCoreGigaChatAgentThreadStore<TContext>` — thread-safe EF Core-backed `IGigaChatAgentThreadStore` using `IDbContextFactory`, with upsert/load/delete and `[Timestamp]` RowVersion optimistic concurrency
- Fixed: null guard on `Arguments` in `GigaChatPendingToolCallDto.ToModel()`
- Fixed: `UnwrapJsonElements` helper converts `JsonElement` back to CLR types after JSON round-trip so `KernelArguments` receive typed values
- Fixed: LINQ materialized with `.ToArray()` before `JsonSerializer.Serialize`
- Fixed: `LoadAsync` wraps deserialization with threadId-contextual `InvalidOperationException`
- 9 integration tests via `Microsoft.EntityFrameworkCore.InMemory` (net8/9/10 only via `#if NET8_0_OR_GREATER`)

## Test plan

- [ ] `dotnet test` — 147 tests pass on net8/9/10, 138 on net6/7
- [ ] `EFCoreThreadStoreTests`: save/load roundtrip, pending tool call, delete, update, steps deserialization

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)