### PR TITLE
[GN-56] feat: DI extensions and interrupt/resume example for EF Core checkpointer

### DIFF
--- a/examples/GigaChat.SemanticKernel.Example/GigaChat.SemanticKernel.Example.csproj
+++ b/examples/GigaChat.SemanticKernel.Example/GigaChat.SemanticKernel.Example.csproj
@@ -10,10 +10,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.76.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.76.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\GigaChat.Net.SemanticKernel\GigaChat.Net.SemanticKernel.csproj" />
+    <ProjectReference Include="..\..\src\GigaChat.Net.EFCore\GigaChat.Net.EFCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/GigaChat.SemanticKernel.Example/Program.cs
+++ b/examples/GigaChat.SemanticKernel.Example/Program.cs
@@ -2,8 +2,10 @@ using System.Globalization;
 using System.ComponentModel;
 using System.Text.Json;
 using GigaChat.Net;
+using GigaChat.Net.EFCore;
 using GigaChat.Net.Models;
 using GigaChat.Net.SemanticKernel;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Agents;
@@ -54,6 +56,10 @@ await RunSectionAsync(
 await RunSectionAsync(
     "GigaChat ReAct agent (GigaChatReActAgent)",
     async () => await RunReActAgentAsync(client, settings.Model, prompt, cts.Token));
+
+await RunSectionAsync(
+    "GigaChat ReAct agent with EF Core checkpointer and interrupt/resume",
+    async () => await RunInterruptResumeAsync(client, settings.Model, prompt, cts.Token));
 
 await RunSectionAsync(
     "GigaChat SDK probes",
@@ -331,6 +337,95 @@ static async Task RunReActAgentAsync(
 
     var thread = await store.LoadAsync(threadId, cancellationToken);
     Console.WriteLine($"Thread history: {thread!.History.Count} messages, {thread.Steps.Count} total steps");
+}
+
+/// <summary>
+/// Demonstrates the EF Core checkpointer together with the interrupt/resume pattern.
+/// Uses SQLite so the thread survives process restarts.
+///
+/// In an ASP.NET Core app the DI setup would be:
+/// <code>
+///   builder.Services.AddGigaChatEFCoreThreadStore&lt;GigaChatDbContext&gt;(opt =>
+///       opt.UseSqlite("Data Source=gigachat-threads.db"));
+/// </code>
+/// And a 202 Accepted pattern for HTTP endpoints:
+/// <code>
+///   app.MapPost("/agent/invoke", async (AgentRequest req, GigaChatReActAgent agent) =>
+///   {
+///       var result = await agent.InvokeAsync(req.Message, req.ThreadId);
+///       return result.Status == GigaChatRunStatus.Interrupted
+///           ? Results.Accepted($"/agent/resume/{req.ThreadId}", new { result.PendingToolCall })
+///           : Results.Ok(result.Messages[0].Content);
+///   });
+///   app.MapPost("/agent/resume/{threadId}", async (
+///       string threadId, ResumeRequest req, GigaChatReActAgent agent) =>
+///   {
+///       var result = await agent.ResumeAsync(threadId, req.HumanInput);
+///       return Results.Ok(result.Messages[0].Content);
+///   });
+/// </code>
+/// </summary>
+static async Task RunInterruptResumeAsync(
+    IGigaChatClient client,
+    string? modelId,
+    string prompt,
+    CancellationToken cancellationToken)
+{
+    // --- DI setup (mirrors ASP.NET Core host registration) ---
+    var services = new ServiceCollection();
+    services.AddGigaChatEFCoreThreadStore<GigaChatDbContext>(opt =>
+        opt.UseSqlite("Data Source=gigachat-threads-example.db"));
+    var sp = services.BuildServiceProvider();
+
+    var store = sp.GetRequiredService<IGigaChatAgentThreadStore>();
+
+    // Ensure schema exists (in production: call db.Database.MigrateAsync() at startup)
+    await using var db = sp.GetRequiredService<IDbContextFactory<GigaChatDbContext>>()
+        .CreateDbContext();
+    await db.Database.EnsureCreatedAsync(cancellationToken);
+
+    // --- Build agent with interrupt-before "release" plugin ---
+    var agent = GigaChatReActAgent.Create(builder =>
+    {
+        builder.UseClient(client);
+        builder.WithInstructions(GigaChatReActInstructions.DefaultRussian);
+        builder.WithModelId(modelId ?? "GigaChat");
+        builder.WithTemperature(0.1);
+        builder.WithMaxToolCalls(3);
+        builder.WithToolSafety(new GigaChatToolSafetyOptions
+        {
+            ErrorBehavior = GigaChatToolErrorBehavior.ReturnObservation,
+            // Pause before any function in the "release" plugin — human approval required
+            InterruptBefore = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "release" }
+        });
+        builder.UseThreadStore(store);
+        builder.AddPlugin(new ReleasePlugin(modelId ?? "GigaChat"), "release");
+    });
+
+    const string threadId = "efcore-interrupt-resume-demo";
+
+    // Turn 1 — agent will hit interrupt before calling the "release" plugin
+    var result = await agent.InvokeAsync(
+        $"Проверь релизный статус для задачи: {prompt}", threadId, cancellationToken);
+
+    if (result.Status == GigaChatRunStatus.Interrupted)
+    {
+        Console.WriteLine($"[Interrupted] Pending tool: {result.PendingToolCall?.PluginName}.{result.PendingToolCall?.FunctionName}");
+        Console.WriteLine("  -> Human approved. Resuming with auto-execution of the pending tool...");
+
+        // Resume: humanInput=null means the SDK invokes the pending tool automatically
+        var resumed = await agent.ResumeAsync(threadId, humanInput: null, cancellationToken);
+        Console.WriteLine($"[Resumed] {resumed.Messages[^1].Content}");
+        Console.WriteLine($"  Steps after resume: {resumed.Steps.Count}");
+    }
+    else
+    {
+        Console.WriteLine($"[Completed without interrupt] {result.Messages[^1].Content}");
+    }
+
+    // Cleanup demo file
+    if (File.Exists("gigachat-threads-example.db"))
+        File.Delete("gigachat-threads-example.db");
 }
 
 static async Task RunSdkProbesAsync(

--- a/src/GigaChat.Net.EFCore/GigaChatEFCoreServiceCollectionExtensions.cs
+++ b/src/GigaChat.Net.EFCore/GigaChatEFCoreServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using GigaChat.Net.SemanticKernel;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GigaChat.Net.EFCore;
+
+/// <summary>
+/// Extension methods on <see cref="IServiceCollection"/> for registering the EF Core checkpointer.
+/// </summary>
+public static class GigaChatEFCoreServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="EFCoreGigaChatAgentThreadStore{TContext}"/> as
+    /// <see cref="IGigaChatAgentThreadStore"/> and adds <see cref="IDbContextFactory{TContext}"/>.
+    /// Works with any EF Core provider (SQLite, SQL Server, PostgreSQL, …).
+    /// </summary>
+    /// <typeparam name="TContext">
+    /// Application DbContext type that derives from <see cref="GigaChatDbContext"/>.
+    /// </typeparam>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="configureDb">Delegate that configures the <see cref="DbContextOptionsBuilder"/>.</param>
+    /// <returns>The same <paramref name="services"/> instance for chaining.</returns>
+    public static IServiceCollection AddGigaChatEFCoreThreadStore<TContext>(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> configureDb)
+        where TContext : GigaChatDbContext
+    {
+        services.AddDbContextFactory<TContext>(configureDb);
+        services.AddSingleton<IGigaChatAgentThreadStore,
+            EFCoreGigaChatAgentThreadStore<TContext>>();
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary

- `AddGigaChatEFCoreThreadStore<TContext>()` extension on `IServiceCollection` — registers `IDbContextFactory` + `EFCoreGigaChatAgentThreadStore` as singleton; provider-agnostic
- `RunInterruptResumeAsync` console example using SQLite: shows DI setup, `InterruptBefore`, `ResumeAsync` with auto tool invocation, and inline ASP.NET Core 202-Accepted pattern in doc comment
- Added `Microsoft.EntityFrameworkCore.Sqlite 9.0.0` reference to example project

## Test plan

- [ ] `dotnet build` — 0 errors
- [ ] `dotnet test` — 147 green on net8/9/10
- [ ] Example compiles and method signature matches issue spec

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)